### PR TITLE
Update lib.php

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -239,8 +239,8 @@ function choicegroup_prepare_options($choicegroup, $user, $coursemodule, $allres
             $option->maxanswers = $choicegroup->maxanswers[$optionid];
             $option->displaylayout = $choicegroup->display;
 
-            if (isset($allresponses[$optionid])) {
-                $option->countanswers = count($allresponses[$optionid]);
+            if (isset($allresponses[$text])) {
+                $option->countanswers = count($allresponses[$text]);
             } else {
                 $option->countanswers = 0;
             }


### PR DESCRIPTION
Some strange error happened in my moodle. Some of the groups showed 'full' sign and rejected further enrolling when the number of members within them was less than the limitation. (well it is a little bit tricky to reproduce the bug. You can choose a few groups with id numbers greater than 4 to initiate a groupchoice with limitation, then you might reproduce this bug.)

(Originally posted https://github.com/ndunand/moodle-mod_choicegroup/issues/6)
