### PR TITLE
Please accept the Estonian translation for mod_choicegroup

### DIFF
--- a/lang/et/choicegroup.php
+++ b/lang/et/choicegroup.php
@@ -1,0 +1,105 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'choicegroup', language 'et', branch 'MOODLE_20_STABLE'
+ *
+ * @package   choicegroup
+ * @copyright 1999 onwards Martin Dougiamas  {@link http://moodle.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['addmorechoices'] = 'Lisa valikuid';
+$string['allowupdate'] = 'Luba valiku muutmine';
+$string['answered'] = 'Vastatud';
+$string['completionsubmit'] = 'Kui kasutaja on valiku teinud, siis kuva seda tegevust edukalt läbituna';
+$string['displayhorizontal'] = 'Kuva horisontaalselt';
+$string['displaymode'] = 'Kuvamise režiim';
+$string['displayvertical'] = 'Kuva vertikaalselt';
+$string['expired'] = 'Vabandust, aga käesolev tegevus sulgus {$a} ja pole enam saadaval';
+$string['fillinatleastoneoption'] = 'Sa pead pakkuma välja vähemalt kaks võimalikku vastust.';
+$string['full'] = '(Täis)';
+$string['havetologin'] = 'Oma valiku esitamiseks pead sa sisse logima';
+$string['choice'] = 'Valik';
+$string['choicegroupclose'] = 'Kuni';
+$string['choicegroup:deleteresponses'] = 'Kustuta kõik vastused';
+$string['choicegroup:downloadresponses'] = 'Lae vastused alla';
+$string['choicegroupfull'] = 'Käesoleva rühma kohtade arv on täis';
+$string['choicegroup:choose'] = 'Salvesta valik';
+$string['choicegroupname'] = 'Rühma valimise nimi';
+$string['choicegroupopen'] = 'Avatud';
+$string['choicegroupoptions'] = 'Valiku sätted';
+$string['choicegroupoptions_help'] = 'Siin märgid Sa ära valikud, mille vahel osalejad valiku tegema peavad.
+
+Võid kasutada just soovitud hulka valikuid. Täitmata jäetud valikuid õppijatele ei näidata. Kui vajad veel rohkem valikuid, siis klõpsa nupul "Lisa vormi veel 3 välja".';
+$string['limitanswers_help'] = 'See valik võimaldab piirata osalejate arvu, kes saavad välja pakutud valikuga liituda. Kui piirarv täis saab, siis ei saa keegi teine seda valikut enam teha.
+
+Kui piirarvud ei ole sisse lülitatud, siis saab iga rühmaga liituda piiramatu arv liikmeid.';
+$string['choicegroup:addinstance'] = 'Lisa uus rühma valimise tegevus';
+$string['choicegroup:readresponses'] = 'Loe vastuseid';
+$string['choicegroupsaved'] = 'Sinu rühma valik on salvestatud';
+$string['choicetext'] = 'Rühma valiku tekst';
+$string['chooseaction'] = 'Vali tegevus...';
+$string['choosegroup'] = 'Vali rühm';
+$string['limit'] = 'Piirarv';
+$string['limitanswers'] = 'Piira lubatud liikmete arvu rühmades';
+$string['modulename'] = 'Rühma valimine';
+$string['modulename_help'] = 'Rühma valimise moodul võimaldab õppijatel iseseisvalt valida endale sobiva rühma.';
+$string['modulenameplural'] = 'Rühma valikud';
+$string['mustchooseone'] = 'Sa pead enne salvestamist tegema valiku. Hetkel ei salvestatud mitte midagi.';
+$string['noguestchoose'] = 'Vabandust, aga külalistel ei ole lubatud valikut teha.';
+$string['noresultsviewable'] = 'Tulemused ei ole praegu avalikult nähtavad.';
+$string['neverresultsviewable'] = 'Tulemused pole avalikud.';
+$string['afterresultsviewable'] = 'Tulemused on nähtavad peale seda, kui oled teinud valiku';
+$string['notyetresultsviewable'] = 'Tulemused muutuvad avalikuks tegevuse sulgumise järel.';
+$string['notanswered'] = 'Pole veel vastanud';
+$string['notenrolledchoose'] = 'Vabandust, aga vaid kursusele registreerunud kasutajatel on lubatud oma valik teha.';
+$string['notopenyet'] = 'Vabandust, aga see tegevus pole veel kättesaadav ja avatakse {$a}';
+$string['option'] = 'Rühm';
+$string['pluginadministration'] = 'Rühma valiku administreerimine';
+$string['pluginname'] = 'Rühma valimine';
+$string['privacy'] = 'Tulemuste privaatsus';
+$string['publish'] = 'Avalda tulemused';
+$string['publishafteranswer'] = 'Näita tulemusi õppijatele peale seda kui nad on vastanud';
+$string['publishafterclose'] = 'Näita tulemusi õppijatele alles siis, kui valik on suletud';
+$string['publishalways'] = 'Näita alati tulemusi õppijatele';
+$string['publishanonymous'] = 'Avalda anonüümsed tulemused ja ära näita õppijate nimesid';
+$string['publishnames'] = 'Avalda täielikud tulemused koos õppijate nimede ja nende valikutega';
+$string['publishnot'] = 'Ära avalda tulemusi õppijatele';
+$string['removemychoicegroup'] = 'Eemalda minu valik';
+$string['removeresponses'] = 'Eemalda kõik vastused';
+$string['responses'] = 'Vastused';
+$string['responsesto'] = 'Vastused valikule {$a}';
+$string['savemychoicegroup'] = 'Salvesta minu valik';
+$string['showunanswered'] = 'Näita eraldi veergu vastamata kasutajatega';
+$string['spaceleft'] = 'koht on vaba';
+$string['spacesleft'] = 'kohta on vaba';
+$string['taken'] = 'Valitud';
+$string['timerestrict'] = 'Piira vastamiste ajaline periood järgnevaks';
+$string['viewallresponses'] = 'Vaata {$a} vastust';
+$string['withselected'] = 'Valitutega';
+$string['yourselection'] = 'Sinu valik';
+$string['skipresultgraph'] = 'Jäta tulemuste graafik vahele';
+$string['moveselectedusersto'] = 'Teisalda valitud kasutajad...';
+$string['numberofuser'] = 'Kasutajate arv';
+$string['groupdoesntexist'] = 'Mõni märgitud rühmadest ei eksisteeri käesoleval kursusel. Õpetaja peaks vajalikud rühmad looma või käesoleva tegevuse sätteid muutma.';
+$string['samegroupused'] = 'Sama rühma ei saa kasutada mitu korda.';
+
+$string['members/max'] = 'Täitumus / Mahtuvus';
+$string['members/'] = 'Täitumus';
+$string['groupmembers'] = 'Rühma liikmed';
+$string['page-mod-choice-x'] = 'Iga rühma valimise mooduli leht';


### PR DESCRIPTION
This is the same translation as in the lang.moodle.org portal but because mod_choicegroup is not available through Moodle translation management for Moodle 2.4 and 2.5 I would like to include it directly in the module.
