### PR TITLE
Remove BOM

### DIFF
--- a/lang/fi/choicegroup.php
+++ b/lang/fi/choicegroup.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 // This file is part of Moodle - http://moodle.org/
 //


### PR DESCRIPTION
Removes a byte order mark which causes some minor display issues in Moodle 2.6 for Finnish users
