### PR TITLE
Bugfix the user's choice cache.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -89,7 +89,7 @@ function choicegroup_user_outline($course, $user, $mod, $choicegroup) {
 /**
  *
  */
-function choicegroup_get_user_answer($choicegroup, $user, $returnArray = FALSE) {
+function choicegroup_get_user_answer($choicegroup, $user, $returnArray = FALSE, $refresh = FALSE) {
     global $DB, $choicegroup_groups;
 
     static $user_answers = array();
@@ -101,12 +101,14 @@ function choicegroup_get_user_answer($choicegroup, $user, $returnArray = FALSE) 
         $userid = $user->id;
     }
 
-    if (isset($user_answers[$userid])) {
+    if (!$refresh and isset($user_answers[$userid])) {
         if ($returnArray === TRUE) {
             return $user_answers[$userid];
         } else {
             return $user_answers[$userid][0];
         }
+    } else {
+        $user_answers = array();
     }
 
     if (!count($choicegroup_groups)) {

--- a/view.php
+++ b/view.php
@@ -80,7 +80,7 @@ if ($action == 'delchoicegroup' and confirm_sesskey() and is_enrolled($context, 
             $event->add_record_snapshot('choicegroup', $choicegroup);
             $event->trigger();
         }
-        $current = choicegroup_get_user_answer($choicegroup, $USER);
+        $current = choicegroup_get_user_answer($choicegroup, $USER, FALSE, TRUE);
         // Update completion state
         $completion = new completion_info($course);
         if ($completion->is_enabled($cm) && $choicegroup->completionsubmit) {


### PR DESCRIPTION
After removing a choice, the method `choicegroup_get_user_answer` returns some outdated data because of its cache. This cause the form to not be fully updated before a manual refresh, e.g., the label _Your selection: xxx_ is still displayed and the link _Remove my choice_ is still visible instead of the button _Save my choice_.

The new `$refresh` parameter solve this problem by reseting the cache.

Example:

**Before I pressed the link *"Remove my choice"***
![screen shot 2014-09-09 at 3 10 13 pm](https://cloud.githubusercontent.com/assets/6701530/4201854/cf0875a4-3822-11e4-9a16-ece29cd4ad6d.png)

**After I pressed the link _"Remove my choice"_ (without the bug fix)**
![screen shot 2014-09-09 at 3 10 27 pm](https://cloud.githubusercontent.com/assets/6701530/4201855/d6cc413a-3822-11e4-8c9f-4e69fdd0c32f.png)

**After I pressed the link _"Remove my choice"_ (with the bug fix)**
![screen shot 2014-09-09 at 3 10 40 pm](https://cloud.githubusercontent.com/assets/6701530/4201856/de10713c-3822-11e4-805b-f3c1f8930f87.png)
