### PR TITLE
Enables Visible Groups filter dropdown list.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -767,14 +767,21 @@ function choicegroup_get_choicegroup($choicegroupid) {
     if ($choicegroup = $DB->get_record("choicegroup", array("id" => $choicegroupid))) {
         $sortcolumn = choicegroup_get_sort_column($choicegroup);
 
-        $sql = "SELECT grp_o.id, grp_o.groupid, grp_o.maxanswers FROM {groups} grp
-            INNER JOIN {choicegroup_options} grp_o on grp.id = grp_o.groupid
-            WHERE grp_o.choicegroupid = :choicegroupid
-            ORDER BY $sortcolumn ASC";
-
         $params = array(
             'choicegroupid' => $choicegroupid
         );
+
+        $grpfilter = '';
+        if (($groupid = optional_param('group', 0, PARAM_INT)) != 0) {
+            $params['groupid'] = $groupid;
+            $grpfilter = "AND grp_o.groupid = :groupid";
+        }
+
+        $sql = "SELECT grp_o.id, grp_o.groupid, grp_o.maxanswers FROM {groups} grp
+            INNER JOIN {choicegroup_options} grp_o on grp.id = grp_o.groupid
+            WHERE grp_o.choicegroupid = :choicegroupid $grpfilter
+            ORDER BY $sortcolumn ASC";
+
         $options = $DB->get_records_sql($sql, $params);
 
         foreach ($options as $option) {


### PR DESCRIPTION
With this fix, the Visible Groups dropdown menu now has a filtering effect on what appears in the page when you selected a particular group. This is very useful when you have many groups.

![image](https://cloud.githubusercontent.com/assets/3808579/11316948/7a5d5360-8fe9-11e5-98c0-1b4f3bad870a.png)

Signed-off-by: Michael Milette <michael.milete@instruxmedia.com>