### PR TITLE
Accessibility for Group choosing

### DIFF
--- a/lang/en/choicegroup.php
+++ b/lang/en/choicegroup.php
@@ -152,3 +152,7 @@ $string['double_click_grouping_legend'] = 'Double click on a grouping to expand/
 $string['double_click_group_legend'] = 'Double click on a group to add it.';
 
 
+$string['grouplimit'] = 'Group limit';
+$string['usegroup'] = 'Use this group';
+
+

--- a/mod_form.php
+++ b/mod_form.php
@@ -128,71 +128,26 @@ class mod_choicegroup_mod_form extends moodleform_mod {
 
 
 		$mform->addElement('header', 'groups', get_string('groupsheader', 'choicegroup'));
-		$mform->addElement('html', '<fieldset class="clearfix">
-				<div class="fcontainer clearfix">
-				<div id="fitem_id_option_0" class="fitem fitem_fselect ">
-				<div class="fitemtitle"><label for="id_option_0">'.get_string('groupsheader', 'choicegroup').'</label><span class="helptooltip"><a href="'. $CFG->wwwroot .'/help.php?component=choicegroup&amp;identifier=choicegroupoptions&amp;lang='.current_language().'" title="'.get_string('choicegroupoptions_help', 'choicegroup').'" aria-haspopup="true" target="_blank"><img src="'.$CFG->wwwroot.'/theme/image.php?theme='.$PAGE->theme->name.'&component=core&image=help" alt="'.get_string('choicegroupoptions_help', 'choicegroup').'" class="iconhelp"></a></span></div><div class="felement fselect">
-                <div class="tablecontainer">
-				<table><tr><th>'.get_string('available_groups', 'choicegroup').'</th><th>&nbsp;</th><th>'.get_string('selected_groups', 'choicegroup').'</th><th>&nbsp;</th></tr><tr><td style="vertical-align: top">');
 
-		$mform->addElement('html','<select id="availablegroups" name="availableGroups" multiple size=10 style="width:200px">');
-		foreach ($groupings as $groupingID => $grouping) {
-			// find all linked groups to this grouping
-			if (isset($grouping->linkedGroupsIDs) && count($grouping->linkedGroupsIDs) > 1) { // grouping has more than 2 items, thus we should display it (otherwise it would be clearer to display only that single group alone)
-				$mform->addElement('html', '<option value="'.$groupingID.'" style="font-weight: bold" class="grouping">'.get_string('char_bullet_expanded', 'choicegroup').$grouping->name.'</option>');
+		$mform->addElement('static', 'groupserror', "", "");
+		foreach ($groupings as $grouping) {
+			if (isset($grouping->linkedGroupsIDs) && count($grouping->linkedGroupsIDs) > 1) {
+				$mform->addElement('html', '<fieldset class="grouping"><legend>'.$grouping->name.'</legend>');
 				foreach ($grouping->linkedGroupsIDs as $linkedGroupID) {
-					if (isset($groups[$linkedGroupID])) {
-						$mform->addElement('html', '<option value="'.$linkedGroupID.'" class="group nested">&nbsp;&nbsp;&nbsp;&nbsp;'.$groups[$linkedGroupID]->name.'</option>');
-						$groups[$linkedGroupID]->mentioned = true;
-					}
-				}
+					$group = $groups[$linkedGroupID];
+					$this->addgroup($group->id, $group->name);
+			        $groups[$linkedGroupID]->mentioned = true;
+			    }
+			    $mform->addElement('html', '</fieldset>');
 			}
 		}
 		foreach ($groups as $group) {
 			if ($group->mentioned === false) {
-				$mform->addElement('html', '<option value="'.$group->id.'" class="group toplevel">'.format_string($group->name).'</option>');
+				$this->addgroup($group->id, $group->name);
 			}
 		}
-		$mform->addElement('html','</select><br><button name="expandButton" type="button" disabled id="expandButton">'.get_string('expand_all_groupings', 'choicegroup').'</button><button name="collapseButton" type="button" disabled id="collapseButton">'.get_string('collapse_all_groupings', 'choicegroup').'</button><br>'.get_string('double_click_grouping_legend', 'choicegroup').'<br>'.get_string('double_click_group_legend', 'choicegroup'));
-
-
-
-
-
-
-		$mform->addElement('html','
-				</td><td><button id="addGroupButton" name="add" type="button" disabled>'.get_string('add', 'choicegroup').'</button><div><button name="remove" type="button" disabled id="removeGroupButton">'.get_string('del', 'choicegroup').'</button></div></td>');
-		$mform->addElement('html','<td style="vertical-align: top"><select id="id_selectedGroups" name="selectedGroups" multiple size=10 style="width:200px"></select></td>');
-
-		$mform->addElement('html','<td><div><div id="fitem_id_limit_0" class="fitem fitem_ftext" style="display:none"><div class=""><label for="id_limit_0" id="label_for_limit_ui">'.get_string('set_limit_for_group', 'choicegroup').'</label></div><div class="ftext">
-				<input class="mod-choicegroup-limit-input" type="text" value="0" id="ui_limit_input" disabled="disabled"></div></div></div></td></tr></table></div>
-				</div></div>
-
-				</div>
-				</fieldset>');
 
 		$mform->setExpanded('groups');
-
-		foreach ($groups as $group) {
-			$mform->addElement('hidden', 'group_' . $group->id . '_limit', '', array('id' => 'group_' . $group->id . '_limit', 'class' => 'limit_input_node'));
-			$mform->setType('group_' . $group->id . '_limit', PARAM_RAW);
-		}
-
-
-		$serializedselectedgroupsValue = '';
-		if (isset($this->_instance) && $this->_instance != '') {
-			// this is presumably edit mode, try to fill in the data for javascript
-			$cg = choicegroup_get_choicegroup($this->_instance);
-			foreach ($cg->option as $optionID => $groupID) {
-				$serializedselectedgroupsValue .= ';' . $groupID;
-				$mform->setDefault('group_' . $groupID . '_limit', $cg->maxanswers[$optionID]);
-			}
-
-		}
-
-
-		$mform->addElement('hidden', 'serializedselectedgroups', $serializedselectedgroupsValue, array('id' => 'serializedselectedgroups'));
-		$mform->setType('serializedselectedgroups', PARAM_RAW);
 
         switch (get_config('choicegroup', 'sortgroupsby')) {
             case CHOICEGROUP_SORTGROUPS_CREATEDATE:
@@ -228,6 +183,23 @@ class mod_choicegroup_mod_form extends moodleform_mod {
 		$this->add_action_buttons();
 }
 
+private function addgroup($groupid, $groupname) {
+	$mform    =& $this->_form;
+	$buttonarray = array();
+    $buttonarray[] =& $mform->createElement('text', 'lgroup['.$groupid.']', get_string('grouplimit', 'choicegroup'),
+                                            array('size' => 4, 'class' => 'limit_input_node'));
+   	$buttonarray[] =& $mform->createElement('checkbox', 'cgroup['.$groupid.']', '',
+                                            ' '.get_string('usegroup', 'choicegroup'));
+    $mform->setType('cgroup['.$groupid.']', PARAM_INT);
+    $mform->setType('lgroup['.$groupid.']', PARAM_INT);
+    $mform->addGroup($buttonarray, 'groupelement', $groupname, array(' '), false);
+    $mform->disabledIf('lgroup['.$groupid.']', 'cgroup['.$groupid.']', 'notchecked');
+    $mform->setDefault('lgroup['.$groupid.']', 0);
+    $mform->addElement('hidden', 'groupid['.$groupid.']', '');
+    $mform->setType('groupid['.$groupid.']', PARAM_INT);
+    $mform->disabledIf('lgroup['.$groupid.']', 'limitanswers', 'eq', 0);
+}
+
 function data_preprocessing(&$default_values){
 	global $DB;
 	$this->js_call();
@@ -238,21 +210,33 @@ function data_preprocessing(&$default_values){
 		$default_values['timerestrict'] = 1;
 	}
 
-	}
+    if (!$this->current->instance) {
+        return;
+    }
+    $groupsok = $DB->get_records('choicegroup_options', array('choicegroupid' => $this->current->instance), 'groupid', 'id, groupid, maxanswers');
+    if (!empty($groupsok)) {
+        $groups = choicegroup_detected_groups($COURSE->id, true);
+        foreach ($groupsok as $group) {
+            if (in_array($group->groupid, $groups)) {
+                $defaultvalues['lgroup['.$group->groupid.']'] = $group->maxanswers;
+                $defaultvalues['cgroup['.$group->groupid.']'] = true;
+                $defaultvalues['groupid['.$group->groupid.']'] = $group->id;
+            }
+        }
+    }
+}
 
 	function validation($data, $files) {
 		$errors = parent::validation($data, $files);
-
-		$groupIDs = explode(';', $data['serializedselectedgroups']);
-		$groupIDs = array_diff( $groupIDs, array( '' ) );
+		$numgroups = isset($data['cgroup']) ? count($data['cgroup']) : 0;
 
 		if (array_key_exists('multipleenrollmentspossible', $data) && $data['multipleenrollmentspossible'] === '1') {
-			if (count($groupIDs) < 1) {
-				$errors['serializedselectedgroups'] = get_string('fillinatleastoneoption', 'choicegroup');
+			if ($numgroups < 1) {
+				$errors['groupserror'] = get_string('fillinatleastoneoption', 'choicegroup');
 			}
 		} else {
-			if (count($groupIDs) < 2) {
-				$errors['serializedselectedgroups'] = get_string('fillinatleasttwooptions', 'choicegroup');
+			if ($numgroups < 2) {
+				$errors['groupserror'] = get_string('fillinatleasttwooptions', 'choicegroup');
 			}
 		}
 

--- a/renderer.php
+++ b/renderer.php
@@ -119,9 +119,11 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
                 $group_members_names[] = $group_user->lastname . ', ' . $group_user->firstname;
             }
             sort($group_members_names);
-            if (!empty($option->attributes->disabled) || ($limitanswers && sizeof($group_members) >= $option->maxanswers) && empty($option->attributes->checked)) {
-                $labeltext .= ' ' . html_writer::tag('em', get_string('full', 'choicegroup'));
-                $option->attributes->disabled=true;
+            if (!empty($option->attributes->disabled) || ($limitanswers && $option->maxanswers > 0 && count($group_members) >= $option->maxanswers) && empty($option->attributes->checked)) {
+                if(($limitanswers && $option->maxanswers > 0 && count($group_members) >= $option->maxanswers) && empty($option->attributes->checked)) {
+                    $labeltext .= ' ' . html_writer::tag('em', get_string('full', 'choicegroup'));
+                }
+                $option->attributes->disabled = true;
                 $availableoption--;
             }
             $labeltext .= html_writer::tag('div', format_text($group->description), array('class' => 'choicegroups-descriptions hidden'));
@@ -139,7 +141,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
             ($showresults == CHOICEGROUP_SHOWRESULTS_AFTER_ANSWER and $current) or
             ($showresults == CHOICEGROUP_SHOWRESULTS_AFTER_CLOSE and !$choicegroupopen)) {
 
-                $maxanswers = ($limitanswers) ? (' / '.$option->maxanswers) : ('');
+                $maxanswers = ($limitanswers && $option->maxanswers > 0 ) ? (' / '.$option->maxanswers) : ('');
                 $html .= html_writer::tag('td', sizeof($group_members_names).$maxanswers, array('class' => 'center'));
                 if ($publish == CHOICEGROUP_PUBLISH_NAMES) {
                     $group_members_html = html_writer::tag('div', implode('<br />', $group_members_names), array('class' => 'choicegroups-membersnames hidden', 'id' => 'choicegroup_'.$option->attributes->value));

--- a/yui/form/form.js
+++ b/yui/form/form.js
@@ -10,20 +10,9 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 	var CSS = {
 	},
 	SELECTORS = {
-			AVAILABLE_GRPS_SELECT: '#availablegroups',
-			AVAILABLE_GRPS_SELECT_OPTIONS: "select[id='availablegroups'] option",
-			SELECTED_GRPS_SELECT: '#id_selectedGroups',
-			ADD_GRP_BTN: '#addGroupButton',
-			DEL_GRP_BTN: '#removeGroupButton',
 			FORM: '#mform1',
-			LIMIT_UI_INPUT: '#ui_limit_input',
-			LIMIT_UI_DIV: '#fitem_id_limit_0',
-			LIMIT_UI_LABEL: '#label_for_limit_ui',
 			APPLY_LIMIT_TO_ALL_GRPS_BTN: '#id_setlimit',
 			ENABLE_DISABLE_LIMITING_SELECT: '#id_limitanswers',
-			EXPAND_ALL_GRPNGS_BTN: '#expandButton',
-			COLLAPSE_ALL_GRPNGS_BTN: '#collapseButton',
-			SERIALIZED_SELECTED_GRPS_LIST: '#serializedselectedgroups',
 			GLOBAL_LIMIT_INPUT: '#id_generallimitation',
 			HIDDEN_LIMIT_INPUTS: 'input.limit_input_node',
 	};
@@ -34,25 +23,12 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 				// -------------------------------
 				// Global Variables
 				// -------------------------------
-
                 var CHAR_LIMITUI_PAR_LEFT = M.util.get_string('char_limitui_parenthesis_start', 'choicegroup');
                 var CHAR_LIMITUI_PAR_RIGHT = M.util.get_string('char_limitui_parenthesis_end', 'choicegroup');
-                var CHAR_SELECT_BULLET_COLLAPSED = M.util.get_string('char_bullet_collapsed', 'choicegroup');
-                var CHAR_SELECT_BULLET_EXPANDED = M.util.get_string('char_bullet_expanded', 'choicegroup');
 
-
-				var availableGroupsNode = Y.one(SELECTORS.AVAILABLE_GRPS_SELECT);
-				var addGroupButtonNode = Y.one(SELECTORS.ADD_GRP_BTN);
-				var selectedGroupsNode = Y.one(SELECTORS.SELECTED_GRPS_SELECT);
-				var removeGroupButtonNode = Y.one(SELECTORS.DEL_GRP_BTN);
 				var formNode = Y.one(SELECTORS.FORM);
-				var uiInputLimitNode = Y.one(SELECTORS.LIMIT_UI_INPUT);
 				var applyLimitToAllGroupsButtonNode = Y.one(SELECTORS.APPLY_LIMIT_TO_ALL_GRPS_BTN);
 				var limitAnswersSelectNode = Y.one(SELECTORS.ENABLE_DISABLE_LIMITING_SELECT);
-				var limitInputUIDIVNode = Y.one(SELECTORS.LIMIT_UI_DIV);
-				var expandButtonNode = Y.one(SELECTORS.EXPAND_ALL_GRPNGS_BTN);
-				var collapseButtonNode = Y.one(SELECTORS.COLLAPSE_ALL_GRPNGS_BTN);
-				var serializedSelectedGroupsListNode = Y.one(SELECTORS.SERIALIZED_SELECTED_GRPS_LIST);
 
 				var groupingsNodesContainer = new Array();
 
@@ -82,97 +58,6 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 							}
 						});
 					}
-					});
-				}
-
-				function addOptionNodeToSelectedGroupsList(optNode) {
-					if (optNode.hasClass('grouping') == true) {
-						// check if option is collapsed
-						if (((typeof groupingsNodesContainer[optNode.get('value')]) == 'undefined') || ( groupingsNodesContainer[optNode.get('value')].length == 0)) {
-							// it is expanded, take nodes from UI
-							// This is a grouping, so instead of adding this item we actually need to add everything underneath it
-							var sib = optNode.next(); // sib means sibling, as in, the next element in the DOM tree
-							while (sib && sib.hasClass('nested') && sib.hasClass('group')) {
-								// add sib
-								selectedGroupsNode.append(sib.cloneNode(true));
-								// go to next node
-								sib = sib.next();
-							}
-						} else {
-							// yes it IS collapsed, need to take the nodes from the container rather than from the UI
-							groupingsNodesContainer[optNode.get('value')].forEach(function (underlyingGroupNode) {
-								selectedGroupsNode.append(underlyingGroupNode.cloneNode(true));
-							});
-						}
-					} else {
-						selectedGroupsNode.append(optNode.cloneNode(true));
-					}
-                    if (limitAnswersSelectNode.get('value') == '1') {
-                        updateLimitUIOfAllSelectedGroups();
-                    }
-				}
-
-				function updateGroupLimit(e) {
-					var selectedOptionsNodes = Y.all(SELECTORS.SELECTED_GRPS_SELECT + " option:checked");
-					// get value of input box
-					var limit = uiInputLimitNode.get('value');
-					selectedOptionsNodes.each(function(optNode) {
-						getInputLimitNodeOfSelectedGroupNode(optNode).set('value', limit);
-                        updateLimitUIOfSelectedGroup(optNode);
-					});
-				}
-
-				function collapseGrouping(groupingNode) {
-					// Change the text of this <option> so that it is marked as collapsed:
-					groupingNode.set('text', CHAR_SELECT_BULLET_COLLAPSED + groupingNode.get('text').substring(1));
-					var sib = groupingNode.next(); // sib means sibling, as in, the next element in the DOM tree
-					while (sib && sib.hasClass('nested') && sib.hasClass('group')) {
-						// save this node somewhere first
-						if (typeof groupingsNodesContainer[groupingNode.get('value')] == 'undefined') {
-							groupingsNodesContainer[groupingNode.get('value')] = new Array();
-						}
-						groupingsNodesContainer[groupingNode.get('value')].push(sib.cloneNode(true));
-						// save the next node before removing the current one
-						var nextSibling = sib.next();
-						sib.remove();
-						// go to next node
-						sib = nextSibling;
-					}
-				}
-
-				function expandGrouping(groupingNode) {
-					// Change the text of this <option> so that it is marked as collapsed:
-					groupingNode.set('text', CHAR_SELECT_BULLET_EXPANDED + groupingNode.get('text').substring(1));
-					var nextOpt = groupingNode.next();
-					if (typeof groupingsNodesContainer[groupingNode.get('value')] != 'undefined') {
-						groupingsNodesContainer[groupingNode.get('value')].forEach(function(underlyingGroupNode) {
-							if (typeof nextOpt != 'undefined') {
-								availableGroupsNode.insertBefore(underlyingGroupNode, nextOpt);
-							} else {
-								availableGroupsNode.appendChild(underlyingGroupNode);
-							}
-						});
-						groupingsNodesContainer[groupingNode.get('value')] = new Array();
-					}
-
-
-				}
-
-				function collapseAllGroupings() {
-					var availableOptionsNodes = Y.all(SELECTORS.AVAILABLE_GRPS_SELECT + " option");
-					availableOptionsNodes.each(function(optNode) {
-						if (optNode.hasClass('grouping') == true) {
-							collapseGrouping(optNode);
-						}
-					});
-				}
-
-				function expandAllGroupings() {
-					var availableOptionsNodes = Y.all(SELECTORS.AVAILABLE_GRPS_SELECT + " option");
-					availableOptionsNodes.each(function(optNode) {
-						if (optNode.hasClass('grouping') == true) {
-							expandGrouping(optNode);
-						}
 					});
 				}
 
@@ -230,58 +115,15 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 					return false;
                 }
 
-				// --------------------------------
-				// this code happens on form load
-				// --------------------------------
-				if (serializedSelectedGroupsListNode.get('value') != '') {
-					var selectedGroups = serializedSelectedGroupsListNode.get('value').split(';');
-					selectedGroups = selectedGroups.filter(function(n) {return n != '';});
-					var availableOptionsNodes = Y.all(SELECTORS.AVAILABLE_GRPS_SELECT + " option");
-					availableOptionsNodes.each(function(optNode) {
-						selectedGroups.forEach(function (selectedGroup) {
-							if (selectedGroup == optNode.get('value')) {
-								addOptionNodeToSelectedGroupsList(optNode);
-							}
-						});
-					});
-					cleanSelectedGroupsList();
-				}
-
-
-				// Collapse all groupings on load
-				collapseAllGroupings();
-				expandButtonNode.set('disabled', false);
                 // If necessary update their limit information
 				if (limitAnswersSelectNode.get('value') == '1') { // limiting is enabled, show limit box
                     updateLimitUIOfAllSelectedGroups();
                 }
 
-				// -------------------------------
-				// -------------------------------
-
-
-
-
-
 
 				// ---------------------------------
 				// Setup UI Bindings (on load)
 				// ---------------------------------
-
-
-				Y.one('#expandButton').on('click', function(e) {
-					expandAllGroupings();
-					expandButtonNode.set('disabled', true);
-					collapseButtonNode.set('disabled', false);
-
-				});
-				Y.one('#collapseButton').on('click', function(e) {
-					collapseAllGroupings();
-					collapseButtonNode.set('disabled', true);
-					expandButtonNode.set('disabled', false);
-
-				});
-
 
 				// On click fill in the limit in every field
 				applyLimitToAllGroupsButtonNode.on('click', function (e) {
@@ -298,125 +140,10 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
                     updateLimitUIOfAllSelectedGroups();
 				});
 
-
-
-
-				formNode.on('submit', function(e) {
-					var selectedOptionsNodes = Y.all(SELECTORS.SELECTED_GRPS_SELECT + " option");
-					if (selectedOptionsNodes.size() < 2) {
-						alert(M.util.get_string('pleasesetgroups', 'choicegroup'));
-				        e.preventDefault();
-				        e.stopPropagation();
-					}
-					var serializedSelection = '';
-					selectedOptionsNodes.each(function(optNode) { serializedSelection += ';' + optNode.get('value'); });
-					serializedSelectedGroupsListNode.set('value', serializedSelection);
-
-				});
-
-
-				availableGroupsNode.on('click', function(e) {
-					var selectedOptionsNodes = Y.all(SELECTORS.AVAILABLE_GRPS_SELECT + " option:checked");
-					if (selectedOptionsNodes.size() >= 2) {
-						var allGroupings = true;
-						selectedOptionsNodes.each(function(optNode){
-							if (optNode.hasClass('grouping') == false) {
-								allGroupings = false;
-							}
-						});
-						if (allGroupings) {
-							addGroupButtonNode.setContent(M.util.get_string('add_groupings', 'choicegroup'));
-						} else {
-							addGroupButtonNode.setContent(M.util.get_string('add_groups', 'choicegroup'));
-						}
-						addGroupButtonNode.set('disabled', false);
-
-					} else if (selectedOptionsNodes.size() >= 1) {
-						var firstNode = selectedOptionsNodes.item(0);
-						if (firstNode.hasClass('grouping')) {
-							addGroupButtonNode.setContent(M.util.get_string('add_grouping', 'choicegroup'));
-							if (wasFirstCharacterClicked(e, firstNode)) {
-								expandOrCollapseGrouping(firstNode);
-							}
-
-						} else {
-							addGroupButtonNode.setContent(M.util.get_string('add_group', 'choicegroup'));
-						}
-						addGroupButtonNode.set('disabled', false);
-
-					} else {
-						addGroupButtonNode.set('disabled', true);
-						addGroupButtonNode.setContent(M.util.get_string('add', 'choicegroup'));
-					}
-
-				});
-				Y.delegate('dblclick', function(e) {
-					if (e.currentTarget.hasClass('grouping') == true) {
-						expandOrCollapseGrouping(e.currentTarget);
-					} else {
-						addOptionNodeToSelectedGroupsList(e.currentTarget);
-						cleanSelectedGroupsList();
-					}
-
-
-				},  Y.config.doc, SELECTORS.AVAILABLE_GRPS_SELECT_OPTIONS, this);
-
-				selectedGroupsNode.on('click', function(e) {
-					var selectedOptionsNodes = Y.all(SELECTORS.SELECTED_GRPS_SELECT + " option:checked");
-					if (selectedOptionsNodes.size() >= 2) {
-						removeGroupButtonNode.setContent(M.util.get_string('del_groups', 'choicegroup'));
-						removeGroupButtonNode.set('disabled', false);
-						uiInputLimitNode.set('disabled', true);
-						//uiInputLimitNode.set('value', 'multiple values');
-						limitInputUIDIVNode.hide();
-
-					} else if (selectedOptionsNodes.size() >= 1) {
-						removeGroupButtonNode.setContent(M.util.get_string('del_group', 'choicegroup'));
-						removeGroupButtonNode.set('disabled', false);
-						uiInputLimitNode.set('disabled', false);
-						uiInputLimitNode.set('value', getInputLimitNodeOfSelectedGroupNode(selectedOptionsNodes.item(0)).get('value'));
-						Y.one(SELECTORS.LIMIT_UI_LABEL).set('text', M.util.get_string('set_limit_for_group', 'choicegroup') + getGroupNameWithoutLimitText(selectedOptionsNodes.item(0)) + ":");
-						if (limitAnswersSelectNode.get('value') == '1') { // limiting is enabled, show limit box
-							limitInputUIDIVNode.show();
-						}
-
-
-					} else {
-						removeGroupButtonNode.set('disabled', true);
-						removeGroupButtonNode.setContent(M.util.get_string('del', 'choicegroup'));
-						uiInputLimitNode.set('disabled', true);
-						limitInputUIDIVNode.hide();
-					}
-
-				});
-
-				uiInputLimitNode.on('change', function(e) { updateGroupLimit(e); });
-				uiInputLimitNode.on('blur', function(e) { updateGroupLimit(e); });
-
-
-				addGroupButtonNode.on('click', function(e) {
-					var selectedOptionsNodes = Y.all(SELECTORS.AVAILABLE_GRPS_SELECT + " option:checked");
-					selectedOptionsNodes.each(function(optNode) { addOptionNodeToSelectedGroupsList(optNode); });
-					cleanSelectedGroupsList();
-				});
-				removeGroupButtonNode.on('click', function(e) {
-					var selectedOptionsNodes = Y.all(SELECTORS.SELECTED_GRPS_SELECT + " option:checked");
-					selectedOptionsNodes.each(function(optNode) {
-							optNode.remove();
-
-					});
-				});
-
 				limitAnswersSelectNode.on('change', function(e) {
 					if (limitAnswersSelectNode.get('value') == '1') { // limiting is enabled, show limit box
-						var selectedOptionsNodes = Y.all(SELECTORS.SELECTED_GRPS_SELECT + " option:checked");
-						if (selectedOptionsNodes.size() == 1) {
-							limitInputUIDIVNode.show();
-						}
                         updateLimitUIOfAllSelectedGroups();
-
 					} else { // limiting is disabled
-						limitInputUIDIVNode.hide();
                         clearLimitUIFromAllSelectedGroups();
 					}
 


### PR DESCRIPTION
Hi Nicolas,

I've seen the changes from version 2.6 to 2.8 and I've been working on some accessibility changes for the 3.0 version.

This is a reopening for the PR #74.

I took some code from a similar plugin: https://github.com/IOC/moodle-mod_choosegroup

When editing the activity the choice of the groups became very confusing. I tried to write a more accessible form to choose the groups and its options.

In order to define which groups are to be used, there's a checkbox next to the group limit input. Thelimit input says what is the maximum number of users to be enroled into the course. It the limit is set to 0 then it will be no limit.

Cheers,
![cdcd9e60-0fa1-11e5-9875-b0373d51aad6](https://cloud.githubusercontent.com/assets/557037/12920096/856b7fd2-cf47-11e5-93be-ae6d890e68a5.png)
