### PR TITLE
Fix a bug where multiple groups are chosen, deleting a group choice a…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -471,6 +471,9 @@ function prepare_choicegroup_show_results($choicegroup, $course, $cm, $allrespon
 
         if (array_key_exists($groupid, $allresponses)) {
             $display->options[$optionid]->user = $allresponses[$groupid];
+            foreach ($display->options[$optionid]->user as $user){
+                $user->grpsmemberid = array_search(array($groupid, $user->id), $choicegroup->grpmemberid);
+            }
             $totaluser += count($allresponses[$groupid]);
         }
     }
@@ -633,23 +636,23 @@ function prepare_choicegroup_show_results($choicegroup, $course, $cm, $allrespon
 
 /**
  * @global object
- * @param array $userids
+ * @param array $grpsmemberids
  * @param object $choicegroup Choice main table row
  * @param object $cm Course-module object
  * @param object $course Course object
  * @return bool
  */
-function choicegroup_delete_responses($userids, $choicegroup, $cm, $course) {
+function choicegroup_delete_responses($grpsmemberids, $choicegroup, $cm, $course) {
     global $CFG, $DB, $context;
     require_once($CFG->libdir.'/completionlib.php');
 
-    if(!is_array($userids) || empty($userids)) {
+    if(!is_array($grpsmemberids) || empty($grpsmemberids)) {
         return false;
     }
 
-    foreach($userids as $num => $userid) {
-        if(empty($userid)) {
-            unset($userids[$num]);
+    foreach($grpsmemberids as $num => $grpsmemberid) {
+        if(empty($grpsmemberid)) {
+            unset($grpsmemberids[$num]);
         }
     }
 
@@ -659,21 +662,22 @@ function choicegroup_delete_responses($userids, $choicegroup, $cm, $course) {
         'objectid' => $choicegroup->id
     );
 
-    foreach($userids as $userid) {
-        if ($current = choicegroup_get_user_answer($choicegroup, $userid)) {
-            $currentgroup = $DB->get_record('groups', array('id' => $current->id), 'id,name', MUST_EXIST);
-            if (groups_is_member($current->id, $userid)) {
-                groups_remove_member($current->id, $userid);
-                $event = \mod_choicegroup\event\choice_removed::create($eventparams);
-                $event->add_record_snapshot('course_modules', $cm);
-                $event->add_record_snapshot('course', $course);
-                $event->add_record_snapshot('choicegroup', $choicegroup);
-                $event->trigger();
-            }
-            // Update completion state
-            if ($completion->is_enabled($cm) && $choicegroup->completionsubmit) {
-                $completion->update_state($cm, COMPLETION_INCOMPLETE, $userid);
-            }
+    foreach($grpsmemberids as $grpsmemberid) {
+        $groupsmember = $DB->get_record('groups_members', array('id'=>$grpsmemberid), '*', MUST_EXIST);
+        $userid = $groupsmember->userid;
+        $groupid = $groupsmember->groupid;
+        $currentgroup = $DB->get_record('groups', array('id' => $groupid), 'id,name', MUST_EXIST);
+        if (groups_is_member($groupid, $userid)) {
+            groups_remove_member($groupid, $userid);
+            $event = \mod_choicegroup\event\choice_removed::create($eventparams);
+            $event->add_record_snapshot('course_modules', $cm);
+            $event->add_record_snapshot('course', $course);
+            $event->add_record_snapshot('choicegroup', $choicegroup);
+            $event->trigger();
+        }
+        // Update completion state
+        if ($completion->is_enabled($cm) && $choicegroup->completionsubmit) {
+            $completion->update_state($cm, COMPLETION_INCOMPLETE, $userid);
         }
     }
     return true;
@@ -782,15 +786,19 @@ function choicegroup_get_choicegroup($choicegroupid) {
             $grpfilter = "AND grp_o.groupid = :groupid";
         }
 
-        $sql = "SELECT grp_o.id, grp_o.groupid, grp_o.maxanswers FROM {groups} grp
-            INNER JOIN {choicegroup_options} grp_o on grp.id = grp_o.groupid
-            WHERE grp_o.choicegroupid = :choicegroupid $grpfilter
-            ORDER BY $sortcolumn ASC";
+        $sql = "SELECT concat(IFNULL(grp_m.id, ''), grp_o.id) uniqueid,
+                    grp_m.id grpmemberid, grp_m.userid, grp_o.id, grp_o.groupid, grp_o.maxanswers
+                FROM {groups} grp
+                INNER JOIN {choicegroup_options} grp_o on grp.id = grp_o.groupid
+                LEFT JOIN {groups_members} grp_m on grp_m.groupid = grp_o.groupid
+                WHERE grp_o.choicegroupid = :choicegroupid $grpfilter
+                ORDER BY $sortcolumn ASC";
 
         $options = $DB->get_records_sql($sql, $params);
 
         foreach ($options as $option) {
             $choicegroup->option[$option->id] = $option->groupid;
+            $choicegroup->grpmemberid[$option->grpmemberid] = array($option->groupid, $option->userid);
             $choicegroup->maxanswers[$option->id] = $option->maxanswers;
         }
 

--- a/renderer.php
+++ b/renderer.php
@@ -277,7 +277,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
                         }
 
                         if ($choicegroups->viewresponsecapability && $choicegroups->deleterepsonsecapability  && $optionid > 0) {
-                            $attemptaction = html_writer::checkbox('userid[]', $user->id,'');
+                            $attemptaction = html_writer::checkbox('grpsmemberid[]', $user->grpsmemberid,'');
                             $data .= html_writer::tag('div', $attemptaction, array('class'=>'attemptaction'));
                         }
                         $userimage = $this->output->user_picture($user, array('courseid'=>$choicegroups->courseid));

--- a/report.php
+++ b/report.php
@@ -32,7 +32,7 @@ $id         = required_param('id', PARAM_INT);   //moduleid
 $format     = optional_param('format', CHOICEGROUP_PUBLISH_NAMES, PARAM_INT);
 $download   = optional_param('download', '', PARAM_ALPHA);
 $action     = optional_param('action', '', PARAM_ALPHA);
-$userids = optional_param_array('userid', array(), PARAM_INT); //get array of responses to delete.
+$grpsmemberids = optional_param_array('grpsmemberid', array(), PARAM_INT); //get array of responses to delete.
 
 $url = new moodle_url('/mod/choicegroup/report.php', array('id'=>$id));
 if ($format !== CHOICEGROUP_PUBLISH_NAMES) {
@@ -79,7 +79,7 @@ $event->add_record_snapshot('choicegroup', $choicegroup);
 $event->trigger();
 
 if (data_submitted() && $action == 'delete' && has_capability('mod/choicegroup:deleteresponses',$context) && confirm_sesskey()) {
-    choicegroup_delete_responses($userids, $choicegroup, $cm, $course); //delete responses.
+    choicegroup_delete_responses($grpsmemberids, $choicegroup, $cm, $course); //delete responses.
     redirect("report.php?id=$cm->id");
 }
 


### PR DESCRIPTION
…lways removes

the student from the group that was created first.

Here is how to recreate the bug.

As Teacher:
1. Manually create three groups, in this order: Test Group 1, Test Group 2, Test Group 3
2. Create a grouping named “Test Grouping”
3. Add the three groups into the grouping
4. Turn editing on, select “Add an activity or resource” and select Group Choice activity, and “Add.”
5. Name the activity “Group Choice test 1”
6. under Miscellaneous settings, check “Allow enrollment to multiple groups.”
leave the other settings as default
Note that the default setting for “Allow choice to be updated” is “No.”
7. under Groups, select the Test Grouping to highlight it under Available Groups on the left.
8. Click “Add Grouping” and confirm that Selected Groups on the right is populated with Test Group 1, Test Group 2, and Test Group 3 (top to bottom).
9. Note that Sort groups by setting is “System Default (currently Group creation date).
Save
As student:
1. select all three group options and “Save my choice”
As Teacher:
1. Open “Group Choice test 1” and click on the link in upper right corner to “View 3 responses by 1 participants”
2. Attempt to delete the student’s choice “Test Group 3,” by selecting the check box next to the student’s name under “Test Group 3,” (on the right), then choose the action “Delete” from the pull-down for “With selected."
Notice that the student was deleted from Test Group 1 (on the left) instead of Test Group 3 (that was selected on the right).

