### PR TITLE
mod_choicegroup: Check user object really exists before cloning it

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -893,10 +893,12 @@ function choicegroup_get_response_data($choicegroup, $cm) {
 
     $responses = choicegroup_get_responses($choicegroup, $ctx);
     foreach ($responses as $response){
-        $allresponses[$response->groupid][$response->userid]= clone $users[$response->userid];
-        $allresponses[$response->groupid][$response->userid]->timemodified =$response->timeadded; 
+        if (isset($users[$response->userid])) {
+            $allresponses[$response->groupid][$response->userid] = clone $users[$response->userid];
+            $allresponses[$response->groupid][$response->userid]->timemodified = $response->timeadded;
 
-        unset($allresponses[0][$response->userid]);
+            unset($allresponses[0][$response->userid]);
+        }
     }
    return $allresponses;
 }


### PR DESCRIPTION
We too have been experiencing https://github.com/ndunand/moodle-mod_choicegroup/issues/98, so I've had a quick look into it. I haven't managed to work out the root cause of the issue -- i.e. how there can be responses returned by choicegroup_get_responses() that don't have a corresponding user object returned by availability->filter_user_list() -- but to avoid the fatal error (which otherwise prevents the page loading at all) I've just added a simple check for the existence of the user object.