### PR TITLE
Mobile support for students

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -1,0 +1,445 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Choice group module external API
+ *
+ * @package    mod_choicegroup
+ * @category   external
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->libdir . '/completionlib.php');
+require_once($CFG->libdir . '/externallib.php');
+require_once($CFG->dirroot . '/mod/choicegroup/lib.php');
+
+/**
+ * Choice group module external functions
+ *
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_choicegroup_external extends external_api {
+
+    /**
+     * Describes the parameters for get_choicegroup_options.
+     *
+     * @return external_function_parameters
+     */
+    public static function get_choicegroup_options_parameters() {
+        return new external_function_parameters(
+            array(
+                'choicegroupid' => new external_value(PARAM_INT, 'Choice group instance id'),
+                'userid' => new external_value(PARAM_INT, 'User id')
+            )
+        );
+    }
+
+    /**
+     * Returns the options list for the provided choice group instance.
+     *
+     * @param int $choicegroupid The choice group id.
+     * @param int $userid The user id.
+     * @param boolean $alloptionsdisabled True when all the options should be disabled, because activity is not open or a limit has been reached.
+     * @return array The choice group options.
+     */
+    public static function get_choicegroup_options($choicegroupid, $userid, $alloptionsdisabled = false) {
+        global $CFG, $choicegroup_groups;
+
+        $result = array();
+        $returnedoptions = array();
+        $warnings = array();
+
+        $params = array(
+            'choicegroupid' => $choicegroupid,
+            'userid' => $userid
+        );
+        $params = self::validate_parameters(self::get_choicegroup_options_parameters(), $params);
+        $choicegroup = choicegroup_get_choicegroup($choicegroupid);
+        $cm = get_coursemodule_from_instance('choicegroup', $choicegroupid);
+        $context = context_module::instance($cm->id);
+
+        self::validate_context($context);
+        require_capability('mod/choicegroup:choose', $context);
+
+        $allresponses = choicegroup_get_response_data($choicegroup, $cm);   // Big function, approx 6 SQL calls per user
+        $answers = choicegroup_get_user_answer($choicegroup, $userid, TRUE);
+
+        foreach ($choicegroup->option as $optionid => $text) {
+            if (isset($text)) {
+                $option = array();
+                $option['id'] = $optionid;
+                $option['groupid'] = $text;
+                $option['name'] = $choicegroup_groups[$text]->name;
+                $option['maxanswers'] = $choicegroup->maxanswers[$optionid];
+                $option['displaylayout'] = $choicegroup->display;
+
+                if (isset($allresponses[$text])) {
+                    $option['countanswers'] = count($allresponses[$text]);
+                } else {
+                    $option['countanswers'] = 0;
+                }
+                // Check if the option has been answered previously by the user.
+                $option['checked'] = false;
+                if (is_array($answers)) {
+                    foreach($answers as $answer) {
+                        if ($answer && $text == $answer->id) {
+                            $option['checked'] = true;
+                        }
+                    }
+                }
+                // Check if the option has to be disabled because the limit has been reached.
+                $limitreached = $choicegroup->limitanswers && ($option['countanswers'] >= $option['maxanswers']);
+                $stillnotanswered = $option['checked'] === false;
+                $option['disabled'] = $alloptionsdisabled;
+                if ($limitreached && $stillnotanswered) {
+                    $option['disabled'] = true;
+                    $option['name'] .= ' '.get_string('full', 'choicegroup');
+                }
+
+                $returnedoptions[] = $option;
+            }
+        }
+
+        $result = array();
+        $result['options'] = $returnedoptions;
+        $result['warnings'] = $warnings;
+        return $result;
+    }
+
+    /**
+     * Describes the get_choicegroup_options return value.
+     *
+     * @return external_single_structure
+     */
+    public static function get_choicegroup_options_returns() {
+
+        return new external_single_structure(
+            array(
+                'options' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'id' => new external_value(PARAM_INT, 'Option id'),
+                            'text' => new external_value(PARAM_RAW, 'Group choice name'),
+                            'maxanswers' => new external_value(PARAM_INT, 'Maximum number of accepted answers', VALUE_OPTIONAL),
+                            'displaylayout' => new external_value(PARAM_INT, 'Display layout', VALUE_OPTIONAL),
+                            'countanswers' => new external_value(PARAM_INT, 'Current number of answers', VALUE_OPTIONAL),
+                            'checked' => new external_value(PARAM_INT, 'Checked', VALUE_OPTIONAL),
+                            'disabled' => new external_value(PARAM_INT, 'Disabled', VALUE_OPTIONAL),
+                        )
+                    )
+                ),
+                'warnings' => new external_warnings(),
+            )
+        );
+    }
+
+    /**
+     * Describes the parameters for view_choicegroup.
+     *
+     * @return external_function_parameters
+     */
+    public static function view_choicegroup_parameters() {
+        return new external_function_parameters(
+            array(
+                'choicegroupid' => new external_value(PARAM_INT, 'Choice group instance id')
+            )
+        );
+    }
+
+    /**
+     * Trigger the course module viewed event and update the module completion status.
+     *
+     * @param int $choicegroupid The choice group id.
+     * @return array of warnings and status result
+     * @throws moodle_exception
+     */
+    public static function view_choicegroup($choicegroupid) {
+        global $DB;
+
+        $params = array(
+            'choicegroupid' => $choicegroupid
+        );
+        $params = self::validate_parameters(self::view_choicegroup_parameters(), $params);
+        $warnings = array();
+
+        // Request and permission validation.
+        $choicegroup = $DB->get_record('choicegroup', array('id' => $params['choicegroupid']), '*', MUST_EXIST);
+        list($course, $cm) = get_course_and_cm_from_instance($choicegroup, 'choicegroup');
+
+        $context = context_module::instance($cm->id);
+        self::validate_context($context);
+        require_capability('mod/choicegroup:choose', $context);
+
+        $event = \mod_choicegroup\event\course_module_viewed::create(array(
+            'objectid' => $choicegroup->id,
+            'context' => $context,
+        ));
+        $event->add_record_snapshot('course', $course);
+        $event->add_record_snapshot('choicegroup', $choicegroup);
+        $event->trigger();
+
+        $completion = new completion_info($course);
+        $completion->set_module_viewed($cm);
+
+        $result = array();
+        $result['status'] = true;
+        $result['warnings'] = $warnings;
+        return $result;
+    }
+
+    /**
+     * Returns description of method result value
+     *
+     * @return external_description
+     */
+    public static function view_choicegroup_returns() {
+        return new external_single_structure(
+            array(
+                'status' => new external_value(PARAM_BOOL, 'Status: true if success'),
+                'warnings' => new external_warnings()
+            )
+        );
+    }
+
+    /**
+     * Describes the parameters for submit_response.
+     *
+     * @return external_function_parameters
+     */
+    public static function submit_choicegroup_response_parameters() {
+        return new external_function_parameters (
+            array(
+                'choicegroupid' => new external_value(PARAM_INT, 'Choice group instance id'),
+                'data' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'name' => new external_value(PARAM_RAW, 'Data name'),
+                            'value' => new external_value(PARAM_RAW, 'Data value'),
+                        )
+                    ),
+                    'The data to be saved',
+                    VALUE_DEFAULT,
+                    array()
+                )
+            )
+        );
+    }
+
+    /**
+     * Returns the options list for the provided choice group instance.
+     *
+     * @param int $choicegroupid The choice group id.
+     * @param array $data The user responses.
+     * @return array The choice group options.
+     */
+    public static function submit_choicegroup_response($choicegroupid, $data) {
+        global $CFG, $DB, $USER;
+
+        $warnings = array();
+
+        $params = array(
+            'choicegroupid' => $choicegroupid,
+            'data' => $data
+        );
+
+        $params = self::validate_parameters(self::submit_choicegroup_response_parameters(), $params);
+
+        if (!$choicegroup = choicegroup_get_choicegroup($choicegroupid)) {
+            throw new moodle_exception('invalidcoursemodule', 'error');
+        }
+        list($course, $cm) = get_course_and_cm_from_instance($choicegroup, 'choicegroup');
+        $context = context_module::instance($cm->id);
+        self::validate_context($context);
+        require_capability('mod/choicegroup:choose', $context);
+
+        $timenow = time();
+        if (!empty($choicegroup->timeopen) && ($choicegroup->timeopen > $timenow)) {
+            throw new moodle_exception('notopenyet', 'choicegroup', '', userdate($choicegroup->timeopen));
+        } else if (!empty($choicegroup->timeclose) && ($timenow > $choicegroup->timeclose)) {
+            throw new moodle_exception('expired', 'choicegroup', '', userdate($choice->timeclose));
+        }
+
+        $responses = self::parse_data_to_responses(
+            $data,
+            $choicegroup->multipleenrollmentspossible
+        );
+        if (empty($responses)) {
+            // Update completion state
+            $completion = new completion_info($course);
+            if ($completion->is_enabled($cm) && $choicegroup->completionsubmit) {
+                $completion->update_state($cm, COMPLETION_INCOMPLETE);
+            }
+        }
+
+        if (!choicegroup_get_user_answer($choicegroup, $USER) || $choicegroup->allowupdate) {
+            if ($choicegroup->multipleenrollmentspossible) {
+                foreach($choicegroup->option as $optionid => $text) {
+                    if (in_array($optionid, $responses)) {
+                        choicegroup_user_submit_response($optionid, $choicegroup, $USER->id, $course, $cm);
+                    } else {
+                        // Remove group selection if selected.
+                        if (groups_is_member($text, $USER->id)) {
+                            $answer_value_group = $DB->get_record('groups', array('id' => $text), 'id, name', MUST_EXIST);
+                            groups_remove_member($answer_value_group->id, $USER->id);
+                            $eventparams = array(
+                                'context' => $context,
+                                'objectid' => $choicegroup->id
+                            );
+                            $event = \mod_choicegroup\event\choice_removed::create($eventparams);
+                            $event->add_record_snapshot('course_modules', $cm);
+                            $event->add_record_snapshot('course', $course);
+                            $event->add_record_snapshot('choicegroup', $choicegroup);
+                            $event->trigger();
+                        }
+                    }
+                }
+            } else { // !multipleenrollmentspossible
+                if (count($responses) == 1) {
+                    $responses = reset($responses);
+                    choicegroup_user_submit_response($responses, $choicegroup, $USER->id, $course, $cm);
+                }
+            }
+        } else {
+            throw new moodle_exception('missingrequiredcapability', 'webservice', '', 'allowupdate');
+        }
+
+        $result = array();
+        $result['status'] = true;
+        $result['warnings'] = $warnings;
+        return $result;
+    }
+
+    /**
+     * Describes the submit_response return value.
+     *
+     * @return external_single_structure
+     */
+    public static function submit_choicegroup_response_returns() {
+
+        return new external_single_structure(
+            array(
+                'status' => new external_value(PARAM_BOOL, 'Status: true if success'),
+                'warnings' => new external_warnings(),
+            )
+        );
+    }
+
+    /**
+     * Extract user responses from the WS data.
+     * @param  array $data The data received from the WS.
+     * @param  boolean $allowmultiple True if more than one response can be selected.
+     * @return array The optionid from the selected responses.
+     */
+    protected static function parse_data_to_responses($data, $allowmultiple) {
+        $responses = array();
+        foreach($data as $index => $datavalue) {
+            $name = $datavalue['name'];
+            $value = $datavalue['value'];
+            if ($allowmultiple) {
+                if ($name != 'responses' && $value === 'true') {
+                    $responses[] = substr($name, strrpos($name, '_')+1);
+                }
+            } else if ($name === 'responses') {
+                $responses[] = $value;
+                break;
+            }
+        }
+
+        return $responses;
+    }
+
+    /**
+     * Describes the parameters for delete_choicegroup_responses.
+     *
+     * @return external_function_parameters
+     */
+    public static function delete_choicegroup_responses_parameters() {
+        return new external_function_parameters (
+            array(
+                'choicegroupid' => new external_value(PARAM_INT, 'Choice group instance id'),
+            )
+        );
+    }
+
+    /**
+     * Delete the given submitted responses in a choice group
+     *
+     * @param int $choicegroupid The choicegroup instance id
+     * @return array status information and warnings
+     * @throws moodle_exception
+     */
+    public static function delete_choicegroup_responses($choicegroupid) {
+        global $USER, $DB;
+
+        $status = false;
+        $warnings = array();
+
+        $params = array(
+            'choicegroupid' => $choicegroupid
+        );
+
+        $params = self::validate_parameters(self::submit_choicegroup_response_parameters(), $params);
+
+        if (!$choicegroup = choicegroup_get_choicegroup($choicegroupid)) {
+            throw new moodle_exception('invalidcoursemodule', 'error');
+        }
+        list($course, $cm) = get_course_and_cm_from_instance($choicegroup, 'choicegroup');
+        $context = context_module::instance($cm->id);
+        self::validate_context($context);
+        require_capability('mod/choicegroup:choose', $context);
+
+        $timenow = time();
+        if (!empty($choicegroup->timeopen) && ($choicegroup->timeopen > $timenow)) {
+            throw new moodle_exception('notopenyet', 'choicegroup', '', userdate($choicegroup->timeopen));
+        } else if (!empty($choicegroup->timeclose) && ($timenow > $choicegroup->timeclose)) {
+            throw new moodle_exception('expired', 'choicegroup', '', userdate($choice->timeclose));
+        }
+
+        $answergiven = choicegroup_get_user_answer($choicegroup, $USER, TRUE);
+        if (!empty($answergiven) && $choicegroup->allowupdate && !$choicegroup->multipleenrollmentspossible) {
+            $params = array('groupid' => reset($answergiven)->id, 'userid' => $USER->id);
+            $groupmember = $DB->get_record('groups_members', $params, 'id', MUST_EXIST);
+            $status = choicegroup_delete_responses([$groupmember->id], $choicegroup, $cm, $course);
+        } else {
+            throw new moodle_exception('missingrequiredcapability', 'webservice', '', 'allowupdate');
+        }
+
+        $result = array(
+            'status' => $status,
+            'warnings' => $warnings
+        );
+        return $result;
+    }
+
+    /**
+     * Describes the delete_choicegroup_responses return value.
+     *
+     * @return external_multiple_structure
+     */
+    public static function delete_choicegroup_responses_returns() {
+        return new external_single_structure(
+            array(
+                'status' => new external_value(PARAM_BOOL, 'status, True if everything went right'),
+                'warnings' => new external_warnings(),
+            )
+        );
+    }
+
+}

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -1,0 +1,134 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mobile output class for Choice group
+ *
+ * @package    mod_choicegroup
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_choicegroup\output;
+
+defined('MOODLE_INTERNAL') || die();
+
+use context_module;
+use mod_choicegroup_external;
+use completion_info;
+
+/**
+ * Mobile output class for Choice group
+ *
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mobile {
+
+    /**
+     * Returns the choice group course view for the mobile app.
+     * @param  array $args Arguments from tool_mobile_get_content WS
+     *
+     * @return array HTML, javascript and otherdata
+     */
+    public static function mobile_course_view($args) {
+        global $OUTPUT, $USER, $DB;
+
+        $args = (object) $args;
+
+        $cm = get_coursemodule_from_id('choicegroup', $args->cmid);
+        $course = $DB->get_record('course', array('id' => $cm->course));
+
+        // Capabilities check.
+        require_login($args->courseid, false, $cm, true, true);
+        $context = context_module::instance($cm->id);
+        require_capability('mod/choicegroup:choose', $context);
+
+        // Get choice_options from external.
+        $choicegroup = choicegroup_get_choicegroup($cm->instance);
+        $current = choicegroup_get_user_answer($choicegroup, $USER);
+
+        // Check if the activity is open.
+        $timenow = time();
+
+        if (!empty($choicegroup->timeopen) && $choicegroup->timeopen > $timenow) {
+            $choicegroup->open = false;
+            $choicegroup->message = get_string("notopenyet", "choicegroup", userdate($choicegroup->timeopen));
+        } else {
+            $choicegroup->open = true;
+        }
+        if (!empty($choicegroup->timeclose) && $timenow > $choicegroup->timeclose) {
+            $choicegroup->expired = true;
+            $choicegroup->message = get_string("expired", "choicegroup", userdate($choicegroup->timeclose));
+        } else {
+            $choicegroup->expired = false;
+        }
+
+        // The user has made her choice and updates are not allowed or choicegroup is not open.
+        $choicegroup->answergiven = choicegroup_get_user_answer($choicegroup, $USER->id);
+        $choicegroup->alloptionsdisabled = (!$choicegroup->open || $choicegroup->expired
+                || ($choicegroup->answergiven && !$choicegroup->allowupdate)
+                || !is_enrolled($context, NULL, 'mod/choicegroup:choose')
+            );
+
+        // Get choicegroup options from external.
+        try {
+            $returnedoptions = mod_choicegroup_external::get_choicegroup_options(
+                $cm->instance,
+                $USER->id,
+                $choicegroup->alloptionsdisabled
+            );
+            $options = array_values($returnedoptions['options']); // Make it mustache compatible.
+            $responses = array();
+            foreach ($options as $option) {
+                if ($choicegroup->multipleenrollmentspossible) {
+                    $responses['responses_'.$option['id']] = $option['checked'];
+                } else if ($option['checked']) {
+                    $responses['responses'] = $option['id'];
+                }
+            }
+        } catch (Exception $e) {
+            $options = array();
+        }
+
+        // Format name and intro.
+        $choicegroup->name = format_string($choicegroup->name);
+        list($choicegroup->intro, $choicegroup->introformat) = external_format_text(
+            $choicegroup->intro,
+            $choicegroup->introformat,
+            $context->id,
+            'mod_choicegroup',
+            'intro'
+        );
+        $data = array(
+            'cmid' => $cm->id,
+            'courseid' => $args->courseid,
+            'choicegroup' => $choicegroup,
+            'options' => $options
+        );
+
+        return array(
+            'templates' => array(
+                array(
+                    'id' => 'main',
+                    'html' => $OUTPUT->render_from_template('mod_choicegroup/mobile_view_page', $data),
+                ),
+            ),
+            'javascript' => '',
+            'otherdata' => array('data' => json_encode($responses))
+        );
+    }
+}

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of the Choice group module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Choice group module capability definition
+ *
+ * @package    mod_choicegroup
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$addons = array(
+    "mod_choicegroup" => array(
+        "handlers" => array( // Different places where the add-on will display content.
+            'coursechoicegroup' => array( // Handler unique name (can be anything)
+                'displaydata' => array(
+                    'title' => 'pluginname',
+                    'icon' => $CFG->wwwroot . '/mod/choicegroup/pix/icon.svg',
+                    'class' => '',
+                ),
+                'delegate' => 'CoreCourseModuleDelegate', // Delegate (where to display the link to the add-on)
+                'method' => 'mobile_course_view', // Main function in \mod_choicegroup\output\mobile
+                'offlinefunctions' => array(
+                    'mobile_course_view' => array(),
+                ), // Function needs caching for offline.
+                'styles' => array(
+                    'url' => $CFG->wwwroot . '/mod/choicegroup/styles_app.css',
+                    'version' => '0.2'
+                ),
+            )
+        ),
+        'lang' => array(
+            array('group', 'moodle'),
+            array('choice', 'choicegroup'),
+            array('choicegroupsaved', 'choicegroup'),
+            array('members/', 'choicegroup'),
+            array('members/max', 'choicegroup'),
+            array('pluginname', 'choicegroup'),
+            array('removemychoicegroup', 'choicegroup'),
+            array('savemychoicegroup', 'choicegroup')
+        )
+    )
+);

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,65 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Choice group external functions and service definitions.
+ *
+ * @package    mod_choicegroup
+ * @category   external
+ * @copyright  2018 Sara Arjona <sara@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+$functions = array(
+
+    'mod_choicegroup_get_choicegroup_options' => array(
+        'classname'     => 'mod_choicegroup_external',
+        'methodname'    => 'get_choicegroup_options',
+        'description'   => 'Retrieve options for a specific choicegroup.',
+        'type'          => 'read',
+        'capabilities'  => 'mod/choicegroup:choose',
+        'services'      => array(MOODLE_OFFICIAL_MOBILE_SERVICE)
+    ),
+
+    'mod_choicegroup_submit_choicegroup_response' => array(
+        'classname'     => 'mod_choicegroup_external',
+        'methodname'    => 'submit_choicegroup_response',
+        'description'   => 'Submit responses to a specific choicegroup item.',
+        'type'          => 'write',
+        'capabilities'  => 'mod/choicegroup:choose',
+        'services'      => array(MOODLE_OFFICIAL_MOBILE_SERVICE)
+    ),
+
+    'mod_choicegroup_view_choicegroup' => array(
+        'classname'     => 'mod_choicegroup_external',
+        'methodname'    => 'view_choicegroup',
+        'description'   => 'Trigger the course module viewed event and update the module completion status.',
+        'type'          => 'write',
+        'capabilities'  => '',
+        'services'      => array(MOODLE_OFFICIAL_MOBILE_SERVICE)
+    ),
+
+    'mod_choicegroup_delete_choicegroup_responses' => array(
+        'classname'     => 'mod_choicegroup_external',
+        'methodname'    => 'delete_choicegroup_responses',
+        'description'   => 'Delete the given submitted responses in a choice group',
+        'type'          => 'write',
+        'capabilities'  => 'mod/choicegroup:choose',
+        'services'      => array(MOODLE_OFFICIAL_MOBILE_SERVICE)
+    ),
+);

--- a/lib.php
+++ b/lib.php
@@ -655,7 +655,7 @@ function prepare_choicegroup_show_results($choicegroup, $course, $cm, $allrespon
  * @return bool
  */
 function choicegroup_delete_responses($grpsmemberids, $choicegroup, $cm, $course) {
-    global $CFG, $DB, $context;
+    global $CFG, $DB;
     require_once($CFG->libdir.'/completionlib.php');
 
     if(!is_array($grpsmemberids) || empty($grpsmemberids)) {
@@ -668,6 +668,7 @@ function choicegroup_delete_responses($grpsmemberids, $choicegroup, $cm, $course
         }
     }
 
+    $context = context_module::instance($cm->id);
     $completion = new completion_info($course);
     $eventparams = array(
         'context' => $context,

--- a/styles_app.css
+++ b/styles_app.css
@@ -1,0 +1,3 @@
+.bold {
+    font-weight: bold;
+}

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -1,0 +1,213 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_choicegroup/mobile_view_page
+
+    Template for the mobile view page.
+
+    Classes required for JS:
+    -
+
+    Data attributes required for JS:
+    -
+
+    Context variables required for this template:
+    * cmid
+    * courseid
+    * choicegroup
+    * options
+
+    Example context (json):
+    {
+      "cmid": "62",
+      "courseid": "3",
+      "choicegroup": {
+        "id": "4",
+        "course": "3",
+        "name": "Group choice activity",
+        "intro": "<p>Select your group</p>",
+        "introformat": "1",
+        "publish": "1",
+        "multipleenrollmentspossible": "1",
+        "showresults": "3",
+        "display": "0",
+        "allowupdate": "0",
+        "showunanswered": "0",
+        "limitanswers": "1",
+        "timeopen": "0",
+        "timeclose": "0",
+        "timemodified": "1528114222",
+        "completionsubmit": "0",
+        "sortgroupsby": "0",
+        "option": {
+          "10": "3",
+          "11": "4",
+          "12": "5"
+        },
+        "grpmemberid": {
+          "6": [
+            "3",
+            "2"
+          ],
+        },
+        "maxanswers": {
+          "12": "1",
+          "11": "2",
+          "10": "2"
+        },
+        "open": true,
+        "expired": false,
+        "alloptionsdisabled": false
+      },
+      "options": [
+        {
+          "id": 10,
+          "groupid": "3",
+          "name": "Group 1",
+          "maxanswers": "1",
+          "displaylayout": "0",
+          "countanswers": 2,
+          "checked": false,
+          "disabled": true
+        },
+        {
+          "id": 11,
+          "groupid": "4",
+          "name": "Group 2",
+          "maxanswers": "2",
+          "displaylayout": "0",
+          "countanswers": 1,
+          "checked": true,
+          "disabled": false
+        },
+        {
+          "id": 12,
+          "groupid": "5",
+          "name": "Group 3",
+          "maxanswers": "2",
+          "displaylayout": "0",
+          "countanswers": 0,
+          "checked": false,
+          "disabled": false
+        }
+      ]
+    }
+}}
+{{=<% %>=}}
+<div>
+    <core-course-module-description description="<% choicegroup.intro %>" component="mod_choicegroup" componentId="<% cmid %>"></core-course-module-description>
+
+    <%# choicegroup.message %>
+    <ion-list>
+        <ion-item>
+                <% choicegroup.message %>
+        </ion-item>
+    </ion-list>
+    <%/ choicegroup.message %>
+
+    <%# choicegroup.open %>
+        <form id="savemychoice">
+
+        <ion-grid>
+            <ion-row>
+                <ion-col class="bold">
+                    {{ 'plugin.mod_choicegroup.group' | translate }}
+                </ion-col>
+                <ion-col col-3 class="bold" justify-content-center align-items-center text-center>
+                    <%^ choicegroup.limitanswers %>
+                        {{ 'plugin.mod_choicegroup.members/' | translate }}
+                    <%/ choicegroup.limitanswers %>
+                    <%# choicegroup.limitanswers %>
+                        {{ 'plugin.mod_choicegroup.members/max' | translate }}
+                    <%/ choicegroup.limitanswers %>
+                </ion-col>
+            </ion-row>
+
+            <%^ choicegroup.multipleenrollmentspossible %>
+                <ion-list radio-group [(ngModel)]="CONTENT_OTHERDATA.data.responses" name="responses">
+            <%/ choicegroup.multipleenrollmentspossible %>
+            <%# choicegroup.multipleenrollmentspossible %>
+                <ion-list>
+            <%/ choicegroup.multipleenrollmentspossible %>
+                <%# options %>
+                    <ion-row>
+                        <ion-col>
+                            <ion-item>
+                                <ion-label><% name %></ion-label>
+                                <%^ choicegroup.multipleenrollmentspossible %>
+                                    <ion-radio <%# checked %>checked="true"<%/ checked %> <%# disabled %>disabled="true"<%/ disabled %> value="<% id %>"></ion-radio>
+                                <%/ choicegroup.multipleenrollmentspossible %>
+                                <%# choicegroup.multipleenrollmentspossible %>
+                                    <ion-checkbox item-right
+                                    [(ngModel)]="CONTENT_OTHERDATA.data.responses_<% id %>" name="responses_<% id %>"
+                                    <%# checked %>checked="true"<%/ checked %>
+                                    <%# disabled %>disabled="true"<%/ disabled %>
+                                    value="<% id %>">
+                                </ion-checkbox>
+                                <%/ choicegroup.multipleenrollmentspossible %>
+                            </ion-item>
+                        </ion-col>
+
+                        <ion-col col-3 justify-content-center align-items-center text-center>
+                            <% countanswers %>
+                            <%# choicegroup.limitanswers %> / <% maxanswers %> <%/ choicegroup.limitanswers %>
+                        </ion-col>
+                    </ion-row>
+                <%/ options %>
+            </ion-list>
+        </ion-grid>
+
+        <%^ choicegroup.expired %>
+            <%^ choicegroup.alloptionsdisabled %>
+                <ion-list>
+                    <ion-item>
+                        <button ion-button block type="submit" core-site-plugins-call-ws name="mod_choicegroup_submit_choicegroup_response"
+                        [params]="{choicegroupid: <% choicegroup.id %>,
+                            data: CoreUtilsProvider.objectToArrayOfObjects(CONTENT_OTHERDATA.data, 'name', 'value')}"
+                        [preSets]="{getFromCache: 0, saveToCache: 0}"
+                        <%^ choicegroup.allowupdate %>confirmMessage<%/ choicegroup.allowupdate %>
+                        successMessage="{{ 'plugin.mod_choicegroup.choicegroupsaved' | translate }}"
+                        refreshOnSuccess="true">
+                            {{ 'plugin.mod_choicegroup.savemychoicegroup' | translate }}
+                        </button>
+                    </ion-item>
+
+                    <%^ choicegroup.multipleenrollmentspossible %>
+                    <%# choicegroup.answergiven %>
+                    <%# choicegroup.allowupdate %>
+                    <ion-item>
+                        <button ion-button block outline color="danger" type="button" core-site-plugins-call-ws name="mod_choicegroup_delete_choicegroup_responses"
+                        [params]="{choicegroupid: <% choicegroup.id %>}"
+                        [preSets]="{getFromCache: 0, saveToCache: 0}"
+                        successMessage="{{ 'plugin.mod_choicegroup.choicegroupsaved' | translate }}"
+                        refreshOnSuccess="true">
+                            <ion-icon name="trash"></ion-icon>&nbsp;
+                            {{ 'plugin.mod_choicegroup.removemychoicegroup' | translate }}
+                        </button>
+                    </ion-item>
+                    <%/ choicegroup.allowupdate %>
+                    <%/ choicegroup.answergiven %>
+                    <%/ choicegroup.multipleenrollmentspossible %>
+                </ion-list>
+            <%/ choicegroup.alloptionsdisabled %>
+        <%/ choicegroup.expired %>
+        </form>
+
+        <!-- Call log WS when the template is loaded. -->
+        <span core-site-plugins-call-ws-on-load name="mod_choicegroup_view_choicegroup" [params]="{choicegroupid: <% choicegroup.id %>}" [preSets]="{getFromCache: 0, saveToCache: 0}"></span>
+    <%/ choicegroup.open %>
+</div>

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2018050101;
+$plugin->version  = 2018060101;
 $plugin->requires  = 2014050800; // Moodle 2.7
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release = '1.11 for Moodle 2.7-3.5 (Build: 2018050101)';


### PR DESCRIPTION
Hi Nicolas!

As we talked some days ago, I've been working during my Project week in Moodle HQ on the first version for supporting your amazing group choice plugin from the mobile app. This version includes the almost fully support from the student point of view. 

Since 3.5 mobile version (which will be released soon), with this patch, students will be able to:
 - View the description, the group names and their choices.
 - Select their group/s choice. If it's simple, a radio button will be shown; otherwise, a checkbox will be displayed.
 - Remove their choice when allowupdate is enabled.
 - See the number of members and capacity (if defined) for each group.
 - Completion support: view and submit completion has been also included to the mobile version.

![Simple group choice](https://user-images.githubusercontent.com/900389/40972145-162462f0-68c0-11e8-8fb9-910c5dbf1ea5.png)
![Multiple group choice](https://user-images.githubusercontent.com/900389/40972182-3091e554-68c0-11e8-94a6-1f9a1a3662d5.png)
![Disabled group choice](https://user-images.githubusercontent.com/900389/40972200-3ab850c2-68c0-11e8-8809-fe51d368baa1.png)


For future releases, there are still other features which could be included:

- Display the group members names information.
- Allow teachers to view responses and export them.
- Add suport from the teachers point of view: creation, modification, deletion...
- Add some phpunit tests for the external web services.

You can test it using some of your Moodle installations through the https://mobileapp.moodledemo.net/ (more information could be found at [Development_workflow](https://docs.moodle.org/dev/Mobile_support_for_plugins#Development_workflow))

Please, let me know if you have any question or you feel I can help you someway! :-)

