### PR TITLE
In Boost, show "Show descriptions/Group Members" buttons as buttons.

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -59,7 +59,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
         $html .= html_writer::tag('th', get_string('choice', 'choicegroup'), array('class'=>'width10'));
 
         $group = get_string('group').' ';
-        $group .= html_writer::tag('a', get_string('showdescription', 'choicegroup'), array('role' => 'button','class' => 'choicegroup-descriptiondisplay choicegroup-descriptionshow btn', 'href' => '#'));
+        $group .= html_writer::tag('a', get_string('showdescription', 'choicegroup'), array('role' => 'button','class' => 'choicegroup-descriptiondisplay choicegroup-descriptionshow btn btn-secondary ml-1', 'href' => '#'));
         $html .= html_writer::tag('th', $group, array('class'=>'width40'));
 
         if ( $showresults == CHOICEGROUP_SHOWRESULTS_ALWAYS or
@@ -72,7 +72,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
                 $html .= html_writer::tag('th', get_string('members/', 'choicegroup'), array('class'=>'width10'));
             }
             if ($publish == CHOICEGROUP_PUBLISH_NAMES) {
-                $membersdisplay_html = html_writer::tag('a', get_string('showgroupmembers','mod_choicegroup'), array('role' => 'button','class' => 'choicegroup-memberdisplay choicegroup-membershow btn', 'href' => '#'));
+                $membersdisplay_html = html_writer::tag('a', get_string('showgroupmembers','mod_choicegroup'), array('role' => 'button','class' => 'choicegroup-memberdisplay choicegroup-membershow btn btn-secondary ml-1', 'href' => '#'));
                 $html .= html_writer::tag('th', get_string('groupmembers', 'choicegroup') .' '. $membersdisplay_html, array('class'=>'width40'));
             }
         }

--- a/styles.css
+++ b/styles.css
@@ -232,7 +232,7 @@
 
 .path-mod-choicegroup a.choicegroup-memberdisplay,
 .path-mod-choicegroup a.choicegroup-descriptiondisplay {
-    display: block;
+    display: inline-block;
 }
 
 .path-mod-choicegroup div.choicegroups-membersnames.hidden,


### PR DESCRIPTION
Dear Nicolas

You could display the show/hide header buttons more as buttons in Boost, and with a consistant look as other buttons in Moodle.

<img width="1103" alt="showhidebuttonstableheader" src="https://user-images.githubusercontent.com/377279/57360380-49d2a080-717a-11e9-8432-449c467d7318.png">

Best,
Luca