### PR TITLE
Provide a 'More help' link to MoodleDocs in activity chooser.

### DIFF
--- a/lang/en/choicegroup.php
+++ b/lang/en/choicegroup.php
@@ -66,6 +66,7 @@ $string['limit'] = 'Limit';
 $string['limitanswers'] = 'Limit the number of responses allowed';
 $string['modulename'] = 'Group choice';
 $string['modulename_help'] = 'The Group Choice module allows students to enrol themselves in a group within a course. The teacher can select which groups students can choose from and the maximum number of students allowed in each group.';
+$string['modulename_link'] = 'mod/choicegroup/view';
 $string['modulenameplural'] = 'Group choices';
 $string['mustchooseone'] = 'You must choose an answer before saving.  Nothing was saved.';
 $string['noguestchoose'] = 'Sorry, guests are not allowed to make choices.';


### PR DESCRIPTION
Thanks!
That would provide such a link:
<img width="357" alt="activitychooserdocslink" src="https://user-images.githubusercontent.com/377279/60027565-fb338400-969d-11e9-8e48-b0d5efd83606.png">
