### PR TITLE
Support offline usage in choicegroup in the Moodle app

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -413,12 +413,17 @@ class mod_choicegroup_external extends external_api {
         }
 
         $answergiven = choicegroup_get_user_answer($choicegroup, $USER, TRUE);
-        if (!empty($answergiven) && $choicegroup->allowupdate && !$choicegroup->multipleenrollmentspossible) {
-            $params = array('groupid' => reset($answergiven)->id, 'userid' => $USER->id);
-            $groupmember = $DB->get_record('groups_members', $params, 'id', MUST_EXIST);
-            $status = choicegroup_delete_responses([$groupmember->id], $choicegroup, $cm, $course);
+        if (!empty($answergiven)) {
+            if ($choicegroup->allowupdate && !$choicegroup->multipleenrollmentspossible) {
+                $params = array('groupid' => reset($answergiven)->id, 'userid' => $USER->id);
+                $groupmember = $DB->get_record('groups_members', $params, 'id', MUST_EXIST);
+                $status = choicegroup_delete_responses([$groupmember->id], $choicegroup, $cm, $course);
+            } else {
+                throw new moodle_exception('missingrequiredcapability', 'webservice', '', 'allowupdate');
+            }
         } else {
-            throw new moodle_exception('missingrequiredcapability', 'webservice', '', 'allowupdate');
+            // User didn't give any answer, so there's no need to delete anything.
+            $status = true;
         }
 
         $result = array(

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -39,6 +39,21 @@ use completion_info;
 class mobile {
 
     /**
+     * Returns the javascript needed to initialize choice group in the app.
+     *
+     * @param  array $args Arguments from tool_mobile_get_content WS
+     * @return array javascript
+     */
+    public static function mobile_init($args) {
+        global $CFG;
+
+        return [
+            'templates' => [],
+            'javascript' => file_get_contents($CFG->dirroot . '/mod/choicegroup/mobile/js/init.js'),
+        ];
+    }
+
+    /**
      * Returns the choice group course view for the mobile app.
      * @param  array $args Arguments from tool_mobile_get_content WS
      *

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -60,7 +60,7 @@ class mobile {
      * @return array HTML, javascript and otherdata
      */
     public static function mobile_course_view($args) {
-        global $OUTPUT, $USER, $DB;
+        global $OUTPUT, $USER, $DB, $CFG;
 
         $args = (object) $args;
 
@@ -142,8 +142,13 @@ class mobile {
                     'html' => $OUTPUT->render_from_template('mod_choicegroup/mobile_view_page', $data),
                 ),
             ),
-            'javascript' => '',
-            'otherdata' => array('data' => json_encode($responses))
+            'javascript' => file_get_contents($CFG->dirroot . '/mod/choicegroup/mobile/js/courseview.js'),
+            'otherdata' => array(
+                'data' => json_encode($responses),
+                'allowupdate' => $choicegroup->allowupdate ? 1 : 0,
+                'multipleenrollmentspossible' => $choicegroup->multipleenrollmentspossible ? 1 : 0,
+                'answergiven' => $choicegroup->answergiven ? 1 : 0,
+            )
         );
     }
 }

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -33,6 +33,7 @@ $addons = array(
                 ),
                 'delegate' => 'CoreCourseModuleDelegate', // Delegate (where to display the link to the add-on)
                 'method' => 'mobile_course_view', // Main function in \mod_choicegroup\output\mobile
+                'init' => 'mobile_init',
                 'offlinefunctions' => array(
                     'mobile_course_view' => array(),
                 ), // Function needs caching for offline.

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -41,6 +41,7 @@ $addons = array(
                     'url' => $CFG->wwwroot . '/mod/choicegroup/styles_app.css',
                     'version' => '0.2'
                 ),
+                'displayrefresh' => false, // Hide default refresh button, a custom one will be used.
             )
         ),
         'lang' => array(

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -49,6 +49,7 @@ $addons = array(
             array('choicegroupsaved', 'choicegroup'),
             array('members/', 'choicegroup'),
             array('members/max', 'choicegroup'),
+            array('modulename', 'choicegroup'),
             array('pluginname', 'choicegroup'),
             array('removemychoicegroup', 'choicegroup'),
             array('savemychoicegroup', 'choicegroup')

--- a/mobile/js/courseview.js
+++ b/mobile/js/courseview.js
@@ -1,0 +1,145 @@
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file is part of the Moodle apps support for the choicegroup plugin.
+ * Defines the function to be used from the mobile course view template.
+ *
+ * @copyright   2019 Dani Palou <dpalou@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+var that = this;
+var allowOffline = this.CoreConfigConstants.versioncode > 3800; // In 3.8.0 and older plugins couldn't add DB schemas.
+var multipleEnrol = this.CONTENT_OTHERDATA.multipleenrollmentspossible;
+
+if (Array.isArray(this.CONTENT_OTHERDATA.data) && this.CONTENT_OTHERDATA.data.length == 0) {
+    // When there are no responses we receive an empty array instead of an empty object. Fix it.
+    this.CONTENT_OTHERDATA.data = {};
+}
+
+var originalData = this.CoreUtilsProvider.clone(this.CONTENT_OTHERDATA.data);
+
+/**
+ * Send responses to the site.
+ */
+this.submitResponses = function() {
+    var promise;
+
+    if (!that.CONTENT_OTHERDATA.allowupdate) {
+        // Ask the user to confirm.
+        that.CoreDomUtilsProvider.showConfirm(that.TranslateService.instant('core.areyousure'));
+    } else {
+        // No need to confirm.
+        promise = Promise.resolve();
+    }
+
+    promise.then(function() {
+        // Submit the responses now.
+        var modal = that.CoreDomUtilsProvider.showModalLoading('core.sending', true);
+        var data = that.CoreUtilsProvider.objectToArrayOfObjects(that.CONTENT_OTHERDATA.data, 'name', 'value');
+
+        that.choiceGroupProvider.submitResponses(that.module.instance, that.module.name, that.courseId, data, allowOffline)
+                .then(function(online) {
+
+            // Responses have been sent to server or stored to be sent later.
+            that.CoreDomUtilsProvider.showToast(that.TranslateService.instant('plugin.mod_choicegroup.choicegroupsaved'));
+
+            if (online) {
+                // Check completion since it could be configured to complete once the user answers the choice.
+                that.CoreCourseProvider.checkModuleCompletion(that.courseId, that.module.completiondata);
+
+                // Data has been sent, refresh the content.
+                return that.refreshContent(true);
+            } else {
+                // Data stored in offline.
+                return that.loadOfflineData();
+            }
+
+        }).catch((message) => {
+            that.CoreDomUtilsProvider.showErrorModalDefault(message, 'Error submitting responses.', true);
+        }).finally(() => {
+            modal.dismiss();
+        });
+    }).catch(() => {
+        // User cancelled, ignore.
+    });
+};
+
+/**
+ * Delete the responses. Only if multiple enrol is not allowed.
+ */
+this.deleteResponses = function() {
+    var modal = that.CoreDomUtilsProvider.showModalLoading('core.sending', true);
+
+    that.choiceGroupProvider.deleteResponses(that.module.instance, that.module.name, that.courseId, allowOffline)
+            .then(function(online) {
+
+        // Responses have been sent to server or stored to be sent later.
+        that.CoreDomUtilsProvider.showToast(that.TranslateService.instant('plugin.mod_choicegroup.choicegroupsaved'));
+
+        if (online) {
+            // Data has been sent, refresh the content.
+            return that.refreshContent(true);
+        } else {
+            // Data stored in offline.
+            return that.loadOfflineData();
+        }
+
+    }).catch((message) => {
+        that.CoreDomUtilsProvider.showErrorModalDefault(message, 'Error deleting responses.', true);
+    }).finally(() => {
+        modal.dismiss();
+    });
+};
+
+/**
+ * Check if the activity has offline data to be sent.
+ *
+ * @return Promise resolved when done.
+ */
+this.loadOfflineData = function() {
+    // Get the offline response if it exists.
+    return that.choiceGroupOffline.getResponse(that.module.instance).then(function(response) {
+        that.hasOffline = true;
+
+        if (response.deleting) {
+            // Uncheck selected option. Delete is only possible if there is no multiple enrolment.
+            delete that.CONTENT_OTHERDATA.data.responses;
+            that.showDelete = false;
+        } else {
+            // Load the offline options into the model.
+            that.CONTENT_OTHERDATA.data = {};
+
+            response.data.forEach(function(entry) {
+                that.CONTENT_OTHERDATA.data[entry.name] = entry.value;
+            });
+
+            that.showDelete = !multipleEnrol; // Show delete if there is offline data and is not multiple enrol.
+        }
+    }).catch(function() {
+        // Offline data not found. Use the original data.
+        that.hasOffline = false;
+        that.showDelete = that.CONTENT_OTHERDATA.answergiven;
+        that.CONTENT_OTHERDATA.data = that.CoreUtilsProvider.clone(originalData);
+    });
+}
+
+this.moduleName = this.TranslateService.instant('plugin.mod_choicegroup.modulename');
+
+// Check if the group choice has offline data.
+this.loadOfflineData().finally(function() {
+    that.loaded = true;
+});

--- a/mobile/js/init.js
+++ b/mobile/js/init.js
@@ -562,11 +562,29 @@ AddonModChoiceGroupSyncCronHandler.prototype.getInterval = function() {
     return choiceGroupSync.syncInterval;
 };
 
-// Register the handler. Wait a bit to make sure the DB tables are created.
+/**
+ * Link handler to treat links to a group choice.
+ */
+
+/**
+ * Handler to treat links to the index page.
+ */
+function AddonModChoiceGroupLinkHandler() {
+    that.CoreContentLinksModuleIndexHandler.call(this, that.CoreCourseHelperProvider, 'AddonModChoiceGroup', 'choicegroup');
+
+    this.name = "AddonModChoiceGroupLinkHandler";
+}
+
+AddonModChoiceGroupLinkHandler.prototype = Object.create(this.CoreContentLinksModuleIndexHandler.prototype);
+AddonModChoiceGroupLinkHandler.prototype.constructor = AddonModChoiceGroupLinkHandler;
+
+// Register the sync handler. Wait a bit to make sure the DB tables are created.
 setTimeout(function() {
     that.CoreCronDelegate.register(new AddonModChoiceGroupSyncCronHandler());
 }, 500);
 
+// Register the link handler.
+this.CoreContentLinksDelegate.registerHandler(new AddonModChoiceGroupLinkHandler());
 
 var result = {
     choiceGroupProvider: choiceGroupProvider,

--- a/mobile/js/init.js
+++ b/mobile/js/init.js
@@ -33,6 +33,7 @@ var CHOICEGROUP_TABLE = 'addon_mod_choicegroup_responses';
 var siteSchema = {
     name: 'AddonModChoiceGroupOfflineProvider',
     version: 1,
+    onlyCurrentSite: true,
     tables: [
         {
             name: CHOICEGROUP_TABLE,

--- a/mobile/js/init.js
+++ b/mobile/js/init.js
@@ -1,0 +1,340 @@
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file is part of the Moodle apps support for the choicegroup plugin.
+ * Defines some "providers" in the app init process so they can be used by all group choices.
+ *
+ * @copyright   2019 Dani Palou <dpalou@moodle.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+var that = this;
+
+/**
+ * Offline provider.
+ */
+
+var CHOICEGROUP_TABLE = 'addon_mod_choicegroup_responses';
+
+// Define the database tables.
+var siteSchema = {
+    name: 'AddonModChoiceGroupOfflineProvider',
+    version: 1,
+    tables: [
+        {
+            name: CHOICEGROUP_TABLE,
+            columns: [
+                {
+                    name: 'choicegroupid',
+                    type: 'INTEGER',
+                    primaryKey: true
+                },
+                {
+                    name: 'name',
+                    type: 'TEXT'
+                },
+                {
+                    name: 'courseid',
+                    type: 'INTEGER'
+                },
+                {
+                    name: 'data',
+                    type: 'TEXT'
+                },
+                {
+                    name: 'deleting',
+                    type: 'INTEGER'
+                },
+                {
+                    name: 'timecreated',
+                    type: 'INTEGER'
+                }
+            ]
+        }
+    ]
+};
+
+/**
+ * Class to handle offline group choices.
+ */
+function AddonModChoiceGroupOfflineProvider() {
+    // Register the schema so the tables are created.
+    that.CoreSitesProvider.registerSiteSchema(siteSchema);
+}
+
+/**
+ * Delete a response stored in DB.
+ *
+ * @param id Group choice ID to remove.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved if deleted, rejected if failure.
+ */
+AddonModChoiceGroupOfflineProvider.prototype.deleteResponse = function(id, siteId) {
+    return that.CoreSitesProvider.getSite(siteId).then(function(site) {
+
+        return site.getDb().deleteRecords(CHOICEGROUP_TABLE, {choicegroupid: id});
+    });
+};
+
+/**
+ * Get all offline responses.
+ *
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved with responses.
+ */
+AddonModChoiceGroupOfflineProvider.prototype.getResponses = function(siteId) {
+    return that.CoreSitesProvider.getSite(siteId).then(function(site) {
+        return site.getDb().getRecords(CHOICEGROUP_TABLE).then(function(records) {
+            // Parse the data of each record.
+            records.forEach(function(record) {
+                record.data = that.CoreTextUtilsProvider.parseJSON(record.data, []);
+            });
+
+            return records;
+        });
+    });
+};
+
+/**
+ * Check if there are offline responses to send.
+ *
+ * @param id Group choice ID.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved with boolean: true if has offline answers, false otherwise.
+ */
+AddonModChoiceGroupOfflineProvider.prototype.hasResponse = function(id, siteId) {
+    return this.getResponse(id, siteId).then(function(response) {
+        return !!response.choicegroupid;
+    }).catch(function() {
+        // No offline data found, return false.
+        return false;
+    });
+};
+
+/**
+ * Get an offline response.
+ *
+ * @param id Group choice ID to get.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved with the stored data.
+ */
+AddonModChoiceGroupOfflineProvider.prototype.getResponse = function(id, siteId) {
+    return that.CoreSitesProvider.getSite(siteId).then((site) => {
+
+        return site.getDb().getRecord(CHOICEGROUP_TABLE, {choicegroupid: id}).then(function(record) {
+            // Parse the data.
+            record.data = that.CoreTextUtilsProvider.parseJSON(record.data, []);
+
+            return record;
+        });
+    });
+};
+
+/**
+ * Store a response to a group choice.
+ *
+ * @param id Group choice ID.
+ * @param name Group choice name.
+ * @param courseId Course ID the group choice belongs to.
+ * @param data List of selected options.
+ * @param deleting If true, the user is deleting responses, if false, submitting.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved when data is successfully stored.
+ */
+AddonModChoiceGroupOfflineProvider.prototype.saveResponses = function(id, name, courseId, data, deleting, siteId) {
+    data = data || [];
+
+    return that.CoreSitesProvider.getSite(siteId).then(function(site) {
+        var entry = {
+            choicegroupid: id,
+            name: name,
+            courseid: courseId,
+            data: JSON.stringify(data),
+            deleting: deleting ? 1 : 0,
+            timecreated: Date.now()
+        };
+
+        return site.getDb().insertRecord(CHOICEGROUP_TABLE, entry);
+    });
+};
+
+var choiceGroupOffline = new AddonModChoiceGroupOfflineProvider();
+
+/**
+ * Group choice provider.
+ */
+
+/**
+ * Class to handle group choices.
+ */
+function AddonModChoiceGroupProvider() {
+    // Register the schema so the tables are created.
+    that.CoreSitesProvider.registerSiteSchema(siteSchema);
+}
+
+/**
+ * Delete responses from a group choice.
+ *
+ * @param id Group choice ID to remove.
+ * @param name The group choice name.
+ * @param courseId Course ID the group choice belongs to.
+ * @param allowOffline Whether to allow storing the data in offline.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved with boolean: true if deleted in server, false if stored in offline. Rejected if failure.
+ */
+AddonModChoiceGroupProvider.prototype.deleteResponses = function(id, name, courseId, allowOffline, siteId) {
+    siteId = siteId || that.CoreSitesProvider.getCurrentSiteId();
+
+    var thisProvider = this;
+
+    // Convenience function to store the delete to be synchronized later.
+    var storeOffline = function() {
+        return choiceGroupOffline.saveResponses(id, name, courseId, undefined, true, siteId).then(function() {
+            return false;
+        });
+    };
+
+    if (!that.CoreAppProvider.isOnline() && allowOffline) {
+        // App is offline, store the action.
+        return storeOffline();
+    }
+
+    // If there's already some data to be sent to the server, discard it first.
+    return choiceGroupOffline.deleteResponse(id, siteId).catch(function() {
+        // Nothing was stored already.
+    }).then(function() {
+        // Now try to delete the responses in the server.
+        return thisProvider.deleteResponsesOnline(id, siteId).then(function() {
+            return true;
+        }).catch(function(error) {
+            if (!allowOffline || that.CoreUtilsProvider.isWebServiceError(error)) {
+                // The WebService has thrown an error, this means that responses cannot be submitted.
+                return Promise.reject(error);
+            }
+
+            // Couldn't connect to server, store in offline.
+            return storeOffline();
+        });
+    });
+};
+
+/**
+ * Delete responses from a group choice. It will fail if offline or cannot connect.
+ *
+ * @param id Group choice ID to remove.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved if deleted, rejected if failure.
+ */
+AddonModChoiceGroupProvider.prototype.deleteResponsesOnline = function(id, siteId) {
+    return that.CoreSitesProvider.getSite(siteId).then(function(site) {
+        var params = {
+            choicegroupid: id
+        };
+
+        return site.write('mod_choicegroup_delete_choicegroup_responses', params).then(function(response) {
+
+            if (!response || response.status === false) {
+                // Couldn't delete the responses. Reject the promise.
+                var error = response && response.warnings && response.warnings[0] ?
+                        response.warnings[0] : that.CoreUtilsProvider.createFakeWSError('');
+
+                return Promise.reject(error);
+            }
+        });
+    });
+};
+
+/**
+ * Send the responses to a group choice.
+ *
+ * @param id Group choice ID to submit.
+ * @param name The group choice name.
+ * @param courseId Course ID the group choice belongs to.
+ * @param data The responses to send.
+ * @param allowOffline Whether to allow storing the data in offline.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved with boolean: true if responses sent to server, false if stored in offline. Rejected if failure.
+ */
+AddonModChoiceGroupProvider.prototype.submitResponses = function(id, name, courseId, data, allowOffline, siteId) {
+    siteId = siteId || that.CoreSitesProvider.getCurrentSiteId();
+
+    var thisProvider = this;
+
+    // Convenience function to store the delete to be synchronized later.
+    var storeOffline = function() {
+        return choiceGroupOffline.saveResponses(id, name, courseId, data, false, siteId).then(function() {
+            return false;
+        });
+    };
+
+    if (!that.CoreAppProvider.isOnline() && allowOffline) {
+        // App is offline, store the action.
+        return storeOffline();
+    }
+
+    // If there's already some data to be sent to the server, discard it first.
+    return choiceGroupOffline.deleteResponse(id, siteId).catch(function() {
+        // Nothing was stored already.
+    }).then(function() {
+        // Now try to delete the responses in the server.
+        return thisProvider.submitResponsesOnline(id, data, siteId).then(function() {
+            return true;
+        }).catch(function(error) {
+            if (!allowOffline || that.CoreUtilsProvider.isWebServiceError(error)) {
+                // The WebService has thrown an error, this means that responses cannot be submitted.
+                return Promise.reject(error);
+            }
+
+            // Couldn't connect to server, store in offline.
+            return storeOffline();
+        });
+    });
+};
+
+/**
+ * Send responses from a group choice to Moodle. It will fail if offline or cannot connect.
+ *
+ * @param id Group choice ID to submit.
+ * @param data The responses to send.
+ * @param siteId Site ID. If not defined, current site.
+ * @return Promise resolved if deleted, rejected if failure.
+ */
+AddonModChoiceGroupProvider.prototype.submitResponsesOnline = function(id, data, siteId) {
+    return that.CoreSitesProvider.getSite(siteId).then(function(site) {
+        var params = {
+            choicegroupid: id,
+            data: data
+        };
+
+        return site.write('mod_choicegroup_submit_choicegroup_response', params).then(function(response) {
+
+            if (!response || response.status === false) {
+                // Couldn't delete the responses. Reject the promise.
+                var error = response && response.warnings && response.warnings[0] ?
+                        response.warnings[0] : that.CoreUtilsProvider.createFakeWSError('');
+
+                return Promise.reject(error);
+            }
+        });
+    });
+};
+
+var result = {
+    choiceGroupProvider: new AddonModChoiceGroupProvider(),
+    choiceGroupOffline: choiceGroupOffline
+};
+
+result;

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -108,8 +108,13 @@
     }
 }}
 {{=<% %>=}}
-<div>
+<core-loading [hideUntil]="loaded">
     <core-course-module-description description="<% choicegroup.intro %>" component="mod_choicegroup" componentId="<% cmid %>"></core-course-module-description>
+
+    <!-- Choice done in offline but not synchronized -->
+    <ion-card class="core-warning-card" icon-start *ngIf="hasOffline">
+        <ion-icon name="warning"></ion-icon> {{ 'core.hasdatatosync' | translate:{$a: moduleName} }}
+    </ion-card>
 
     <%# choicegroup.message %>
     <ion-list>
@@ -175,32 +180,20 @@
             <%^ choicegroup.alloptionsdisabled %>
                 <ion-list>
                     <ion-item>
-                        <button ion-button block type="submit" core-site-plugins-call-ws name="mod_choicegroup_submit_choicegroup_response"
-                        [params]="{choicegroupid: <% choicegroup.id %>,
-                            data: CoreUtilsProvider.objectToArrayOfObjects(CONTENT_OTHERDATA.data, 'name', 'value')}"
-                        [preSets]="{getFromCache: 0, saveToCache: 0}"
-                        <%^ choicegroup.allowupdate %>confirmMessage<%/ choicegroup.allowupdate %>
-                        successMessage="{{ 'plugin.mod_choicegroup.choicegroupsaved' | translate }}"
-                        refreshOnSuccess="true">
+                        <button ion-button block type="submit" (click)="submitResponses()">
                             {{ 'plugin.mod_choicegroup.savemychoicegroup' | translate }}
                         </button>
                     </ion-item>
 
                     <%^ choicegroup.multipleenrollmentspossible %>
-                    <%# choicegroup.answergiven %>
                     <%# choicegroup.allowupdate %>
-                    <ion-item>
-                        <button ion-button block outline color="danger" type="button" core-site-plugins-call-ws name="mod_choicegroup_delete_choicegroup_responses"
-                        [params]="{choicegroupid: <% choicegroup.id %>}"
-                        [preSets]="{getFromCache: 0, saveToCache: 0}"
-                        successMessage="{{ 'plugin.mod_choicegroup.choicegroupsaved' | translate }}"
-                        refreshOnSuccess="true">
+                    <ion-item *ngIf="showDelete">
+                        <button ion-button block outline color="danger" type="button" (click)="deleteResponses()">
                             <ion-icon name="trash"></ion-icon>&nbsp;
                             {{ 'plugin.mod_choicegroup.removemychoicegroup' | translate }}
                         </button>
                     </ion-item>
                     <%/ choicegroup.allowupdate %>
-                    <%/ choicegroup.answergiven %>
                     <%/ choicegroup.multipleenrollmentspossible %>
                 </ion-list>
             <%/ choicegroup.alloptionsdisabled %>
@@ -210,4 +203,4 @@
         <!-- Call log WS when the template is loaded. -->
         <span core-site-plugins-call-ws-on-load name="mod_choicegroup_view_choicegroup" [params]="{choicegroupid: <% choicegroup.id %>}" [preSets]="{getFromCache: 0, saveToCache: 0}"></span>
     <%/ choicegroup.open %>
-</div>
+</core-loading>

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -108,6 +108,15 @@
     }
 }}
 {{=<% %>=}}
+<!-- Add options to the context menu. -->
+<core-navbar-buttons end>
+    <core-context-menu>
+        <core-context-menu-item *ngIf="loaded && !hasOffline && isOnline" [priority]="700" [content]="'core.refresh' | translate" (action)="doRefresh($event)" [iconAction]="refreshIcon" [closeOnClick]="false"></core-context-menu-item>
+
+        <core-context-menu-item *ngIf="loaded && hasOffline && isOnline"  [priority]="650" [content]="'core.settings.synchronizenow' | translate" (action)="synchronize(true, $event)" [iconAction]="syncIcon" [closeOnClick]="false"></core-context-menu-item>
+    </core-context-menu>
+</core-navbar-buttons>
+
 <core-loading [hideUntil]="loaded">
     <core-course-module-description description="<% choicegroup.intro %>" component="mod_choicegroup" componentId="<% cmid %>"></core-course-module-description>
 


### PR DESCRIPTION
Hi Nicolas,

I'm Dani, one of the developers of the Moodle app. In my last project week I worked on adding offline support to your plugin, and here's the result. I chose your plugin because it already had mobile support and because it's quite similar to the choice activity, so I could reuse a lot of code.

Now other plugin developers will have an example if they want to add offline support to their plugins :)

Hopefully in the future there'll be a way to program this using ES9 or so, but for now it needs to be ES5 to make it work on old devices.

If you want to test this, just open a choicegroup activity in the app, go offline and answer or delete the answer. The app should display a message saying there is data to synchronize, and that data can be synchronized manually (using the top-right menu) or automatically after a few minutes. Please notice you need the Moodle app 3.8.1 or higher in order for this to work.

Cheers,
Dani