### PR TITLE
Always get the correct mod edit mform (#143)

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -293,7 +293,8 @@ function data_preprocessing(&$default_values){
 
 	public function js_call() {
 		global $PAGE;
-		$PAGE->requires->yui_module('moodle-mod_choicegroup-form', 'Y.Moodle.mod_choicegroup.form.init');
+		$params = [$this->_form->getAttribute('id')];
+		$PAGE->requires->yui_module('moodle-mod_choicegroup-form', 'Y.Moodle.mod_choicegroup.form.init', $params);
 		foreach (array_keys(get_string_manager()->load_component_strings('choicegroup', current_language())) as $string) {
 			$PAGE->requires->string_for_js($string, 'choicegroup');
 		}

--- a/yui/form/form.js
+++ b/yui/form/form.js
@@ -15,7 +15,6 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 			SELECTED_GRPS_SELECT: '#id_selectedGroups',
 			ADD_GRP_BTN: '#addGroupButton',
 			DEL_GRP_BTN: '#removeGroupButton',
-			FORM: 'form.mform',
 			LIMIT_UI_INPUT: '#ui_limit_input',
 			LIMIT_UI_DIV: '#fitem_id_limit_0',
 			LIMIT_UI_LABEL: '#label_for_limit_ui',
@@ -29,7 +28,7 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 	};
 	Y.namespace('Moodle.mod_choicegroup.form');
 	Y.Moodle.mod_choicegroup.form = {
-			init: function() {
+			init: function(formid) {
 
 				// -------------------------------
 				// Global Variables
@@ -45,7 +44,7 @@ YUI.add('moodle-mod_choicegroup-form', function(Y) {
 				var addGroupButtonNode = Y.one(SELECTORS.ADD_GRP_BTN);
 				var selectedGroupsNode = Y.one(SELECTORS.SELECTED_GRPS_SELECT);
 				var removeGroupButtonNode = Y.one(SELECTORS.DEL_GRP_BTN);
-				var formNode = Y.one(SELECTORS.FORM);
+				var formNode = Y.one('#' + formid);
 				var uiInputLimitNode = Y.one(SELECTORS.LIMIT_UI_INPUT);
 				var applyLimitToAllGroupsButtonNode = Y.one(SELECTORS.APPLY_LIMIT_TO_ALL_GRPS_BTN);
 				var limitAnswersSelectNode = Y.one(SELECTORS.ENABLE_DISABLE_LIMITING_SELECT);


### PR DESCRIPTION
There can be multiple Moodle forms on a page. Particularly with global search enabled in Moodle 3.10 and up - the menu bar contains one. 
This patch gets the proper form's unique ID of the mod edit form for the javascript, instead of just assuming the first form.mform will be what we are looking for.