### PR TITLE
mod_choicegroup: Add option to filter out expired/suspended users

### DIFF
--- a/backup/moodle2/backup_choicegroup_stepslib.php
+++ b/backup/moodle2/backup_choicegroup_stepslib.php
@@ -42,7 +42,7 @@ class backup_choicegroup_activity_structure_step extends backup_activity_structu
             'multipleenrollmentspossible',
             'showresults', 'display', 'allowupdate', 'showunanswered',
             'limitanswers', 'timeopen', 'timeclose', 'timemodified',
-            'completionsubmit', 'sortgroupsby'));
+            'completionsubmit', 'sortgroupsby', 'onlyactive'));
 
         $options = new backup_nested_element('options');
 

--- a/classes/external.php
+++ b/classes/external.php
@@ -78,7 +78,8 @@ class mod_choicegroup_external extends external_api {
         self::validate_context($context);
         require_capability('mod/choicegroup:choose', $context);
 
-        $allresponses = choicegroup_get_response_data($choicegroup, $cm);   // Big function, approx 6 SQL calls per user
+        $groupmode = groups_get_activity_groupmode($cm);
+        $allresponses = choicegroup_get_response_data($choicegroup, $cm, $groupmode, $choicegroup->onlyactive);
         $answers = choicegroup_get_user_answer($choicegroup, $userid, true);
 
         foreach ($choicegroup->option as $optionid => $text) {

--- a/db/install.xml
+++ b/db/install.xml
@@ -23,7 +23,8 @@
         <FIELD NAME="timeclose" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="timeopen" NEXT="timemodified"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="timeclose" NEXT="completionsubmit"/>
         <FIELD NAME="completionsubmit" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" COMMENT="If this field is set to 1, then the activity will be automatically marked as 'complete' once the user submits their choicegroup." PREVIOUS="timemodified" NEXT="sortgroupsby"/>
-        <FIELD NAME="sortgroupsby" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" COMMENT="Column used to sort groups." PREVIOUS="completionsubmit"/>
+        <FIELD NAME="sortgroupsby" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" COMMENT="Column used to sort groups." PREVIOUS="completionsubmit" NEXT="onlyactive"/>
+        <FIELD NAME="onlyactive" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" COMMENT="If this field is set to 1, users with expired or suspended enrolments will be filtered out of response data." PREVIOUS="sortgroupsby"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -82,7 +82,20 @@ function xmldb_choicegroup_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021071400, 'choicegroup');
     }
 
+    if ($oldversion < 2021080500) {
+
+        // Define field onlyactive to be added to choicegroup.
+        $table = new xmldb_table('choicegroup');
+        $field = new xmldb_field('onlyactive', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'sortgroupsby');
+
+        // Conditionally launch add field onlyactive.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Group choice savepoint reached.
+        upgrade_mod_savepoint(true, 2021080500, 'choicegroup');
+    }
+
     return true;
 }
-
-

--- a/lang/en/choicegroup.php
+++ b/lang/en/choicegroup.php
@@ -78,6 +78,7 @@ $string['notyetresultsviewable'] = 'The results will be visible after this activ
 $string['notanswered'] = 'Not answered yet';
 $string['notenrolledchoose'] = 'Sorry, only enrolled users are allowed to make choices.';
 $string['notopenyet'] = 'Sorry, this activity is not available until {$a}';
+$string['onlyactive'] = 'Filter out response data for users with expired or suspended enrolments';
 $string['option'] = 'Group';
 $string['pluginadministration'] = 'Choice administration';
 $string['pluginname'] = 'Group choice';

--- a/lib.php
+++ b/lib.php
@@ -884,7 +884,7 @@ function choicegroup_reset_course_form_defaults($course) {
  * @uses CONTEXT_MODULE
  * @param object $choicegroup
  * @param object $cm
- * @param int $groupmode
+ * @param int $groupmode Group mode
  * @param bool $onlyactive Whether to get response data for active users only
  * @return array
  */
@@ -916,7 +916,7 @@ function choicegroup_get_response_data($choicegroup, $cm, $groupmode, $onlyactiv
 
     $allresponses[0] = $users;
 
-    $responses = choicegroup_get_responses($choicegroup, $ctx);
+    $responses = choicegroup_get_responses($choicegroup, $ctx, $currentgroup, $onlyactive);
     foreach ($responses as $response){
         if (isset($users[$response->userid])) {
             $allresponses[$response->groupid][$response->userid] = clone $users[$response->userid];
@@ -931,10 +931,12 @@ function choicegroup_get_response_data($choicegroup, $cm, $groupmode, $onlyactiv
 /* Return an array with the options selected of users of the $choicegroup 
  * 
  * @param object $choicegroup choicegroup record
- * @param object $cm course module object
+ * @param context_module $ctx Context instance
+ * @param int $currentgroup Current group
+ * @param bool $onlyactive Whether to get responses for active users only
  * @return array of selected options by all users 
 */
-function choicegroup_get_responses($choicegroup, $cm){
+function choicegroup_get_responses($choicegroup, $ctx, $currentgroup, $onlyactive) {
 
     global $DB;
 
@@ -945,7 +947,7 @@ function choicegroup_get_responses($choicegroup, $cm){
     }
 
     $params1 = array('choicegroupid'=>$choicegroupid);
-    list($esql, $params2) = get_enrolled_sql($cm, 'mod/choicegroup:choose', 0);
+    list($esql, $params2) = get_enrolled_sql($ctx, 'mod/choicegroup:choose', $currentgroup, $onlyactive);
     $params = array_merge($params1, $params2);
 
     $sql = 'SELECT gm.* FROM {user} u JOIN ('.$esql.') je ON je.id = u.id

--- a/lib.php
+++ b/lib.php
@@ -884,20 +884,29 @@ function choicegroup_reset_course_form_defaults($course) {
  * @uses CONTEXT_MODULE
  * @param object $choicegroup
  * @param object $cm
+ * @param int $groupmode
+ * @param bool $onlyactive Whether to get response data for active users only
  * @return array
  */
-function choicegroup_get_response_data($choicegroup, $cm) {
+function choicegroup_get_response_data($choicegroup, $cm, $groupmode, $onlyactive) {
     // Initialise the returned array, which is a matrix:  $allresponses[responseid][userid] = responseobject.
     static $allresponses = array();
 
     if (count($allresponses)) {
         return $allresponses;
     }
- 
+
+    // Get the current group.
+    if ($groupmode > 0) {
+        $currentgroup = groups_get_activity_group($cm);
+    } else {
+        $currentgroup = 0;
+    }
+
     // First get all the users who have access here.
     // To start with we assume they are all "unanswered" then move them later.
     $ctx = \context_module::instance($cm->id);
-    $users = get_enrolled_users($ctx, 'mod/choicegroup:choose', 0, 'u.*', 'u.lastname ASC,u.firstname ASC');
+    $users = get_enrolled_users($ctx, 'mod/choicegroup:choose', $currentgroup, 'u.*', 'u.lastname, u.firstname', 0, 0, $onlyactive);
     if ($users) {
         $modinfo = get_fast_modinfo($cm->course);
         $cminfo = $modinfo->get_cm($cm->id);
@@ -1003,7 +1012,9 @@ function choicegroup_extend_settings_navigation(settings_navigation $settings, n
             print_error('invalidcoursemodule');
             return false;
         }
-        $allresponses = choicegroup_get_response_data($choicegroup, $PAGE->cm, $groupmode);   // Big function, approx 6 SQL calls per user
+
+        // Big function, approx 6 SQL calls per user.
+        $allresponses = choicegroup_get_response_data($choicegroup, $PAGE->cm, $groupmode, $choicegroup->onlyactive);
 
         $responsecount = 0;
         $respondents = array();

--- a/mod_form.php
+++ b/mod_form.php
@@ -121,6 +121,9 @@ class mod_choicegroup_mod_form extends moodleform_mod
 
         $mform->addElement('selectyesno', 'showunanswered', get_string("showunanswered", "choicegroup"));
 
+        $mform->addElement('selectyesno', 'onlyactive', get_string('onlyactive', 'choicegroup'));
+        $mform->setDefault('onlyactive', 0);
+
         $menuoptions = array();
         $menuoptions[0] = get_string('disable');
         $menuoptions[1] = get_string('enable');
@@ -328,4 +331,3 @@ class mod_choicegroup_mod_form extends moodleform_mod
     }
 
 }
-

--- a/renderer.php
+++ b/renderer.php
@@ -42,10 +42,11 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
      * @param bool $choicegroupopen
      * @param bool $disabled
      * @param bool $multipleenrollmentspossible
+     * @param bool $onlyactive
      *
      * @return string
      */
-    public function display_options($options, $coursemoduleid, $vertical = true, $publish = false, $limitanswers = false, $showresults = false, $current = false, $choicegroupopen = false, $disabled = false, $multipleenrollmentspossible = false) {
+    public function display_options($options, $coursemoduleid, $vertical = true, $publish = false, $limitanswers = false, $showresults = false, $current = false, $choicegroupopen = false, $disabled = false, $multipleenrollmentspossible = false, $onlyactive = false) {
         global $DB, $PAGE, $choicegroup_groups, $choicegroup_users;
 
         $target = new moodle_url('/mod/choicegroup/view.php');
@@ -114,10 +115,14 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
                 }
             }
 
+            $context = \context_course::instance($group->courseid);
             $labeltext = html_writer::tag('label', format_string($group->name), array('for' => 'choiceid_' . $option->attributes->value));
             $group_members = $DB->get_records('groups_members', array('groupid' => $group->id));
             $group_members_names = array();
             foreach ($group_members as $group_member) {
+                if (!is_enrolled($context, $group_member->userid, '', $onlyactive)) {
+                    continue;
+                }
                 $group_user = (isset($choicegroup_users[$group_member->userid])) ? ($choicegroup_users[$group_member->userid]) : ($DB->get_record('user', array('id' => $group_member->userid)));
                 $group_members_names[] = $group_user->lastname . ', ' . $group_user->firstname;
             }
@@ -127,7 +132,6 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
                 $option->attributes->disabled=true;
                 $availableoption--;
             }
-            $context = \context_course::instance($group->courseid);
             $labeltext .= html_writer::tag('div', format_text(file_rewrite_pluginfile_urls($group->description,
             'pluginfile.php',
                 $context->id,

--- a/renderer.php
+++ b/renderer.php
@@ -47,7 +47,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
      * @return string
      */
     public function display_options($options, $coursemoduleid, $vertical = true, $publish = false, $limitanswers = false, $showresults = false, $current = false, $choicegroupopen = false, $disabled = false, $multipleenrollmentspossible = false, $onlyactive = false) {
-        global $DB, $PAGE, $choicegroup_groups, $choicegroup_users;
+        global $DB, $PAGE, $choicegroup_groups;
 
         $target = new moodle_url('/mod/choicegroup/view.php');
         $attributes = array('method'=>'POST', 'action'=>$target, 'class'=> 'tableform');
@@ -117,16 +117,11 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
 
             $context = \context_course::instance($group->courseid);
             $labeltext = html_writer::tag('label', format_string($group->name), array('for' => 'choiceid_' . $option->attributes->value));
-            $group_members = $DB->get_records('groups_members', array('groupid' => $group->id));
+            $group_members = get_enrolled_users($context, '', $group->id, 'u.*', 'u.lastname, u.firstname', 0, 0, $onlyactive);
             $group_members_names = array();
             foreach ($group_members as $group_member) {
-                if (!is_enrolled($context, $group_member->userid, '', $onlyactive)) {
-                    continue;
-                }
-                $group_user = (isset($choicegroup_users[$group_member->userid])) ? ($choicegroup_users[$group_member->userid]) : ($DB->get_record('user', array('id' => $group_member->userid)));
-                $group_members_names[] = $group_user->lastname . ', ' . $group_user->firstname;
+                $group_members_names[] = fullname($group_member);
             }
-            sort($group_members_names);
             if (!empty($option->attributes->disabled) || ($limitanswers && sizeof($group_members) >= $option->maxanswers) && empty($option->attributes->checked)) {
                 $labeltext .= ' ' . html_writer::tag('em', get_string('full', 'choicegroup'));
                 $option->attributes->disabled=true;

--- a/report.php
+++ b/report.php
@@ -102,7 +102,7 @@ if (!$download) {
         $groups_ids[] = $group->id;
     }
 }
-$users = choicegroup_get_response_data($choicegroup, $cm, $groupmode);
+$users = choicegroup_get_response_data($choicegroup, $cm, $groupmode, $choicegroup->onlyactive);
 
 if ($download == "ods" && has_capability('mod/choicegroup:downloadresponses', $context)) {
     require_once("$CFG->libdir/odslib.class.php");

--- a/version.php
+++ b/version.php
@@ -26,11 +26,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021071400;
+$plugin->version  = 2021080500;
 $plugin->requires  = 2018051700; // Moodle 3.5
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release = '1.31 for Moodle 3.5-3.11 (Build: 2021060200)';
+$plugin->release = '1.32 for Moodle 3.5-3.11 (Build: 2021080500)';
 
 $plugin->component = 'mod_choicegroup';
 $plugin->cron = 0;
-

--- a/view.php
+++ b/view.php
@@ -251,10 +251,10 @@ $renderer = $PAGE->get_renderer('mod_choicegroup');
 if ( (!$current or $choicegroup->allowupdate) and $choicegroupopen and is_enrolled($context, null, 'mod/choicegroup:choose')) {
 // They haven't made their choicegroup yet or updates allowed and choicegroup is open
 
-    echo $renderer->display_options($options, $cm->id, $choicegroup->display, $choicegroup->publish, $choicegroup->limitanswers, $choicegroup->showresults, $current, $choicegroupopen, false, $choicegroup->multipleenrollmentspossible);
+    echo $renderer->display_options($options, $cm->id, $choicegroup->display, $choicegroup->publish, $choicegroup->limitanswers, $choicegroup->showresults, $current, $choicegroupopen, false, $choicegroup->multipleenrollmentspossible, $choicegroup->onlyactive);
 } else {
     // form can not be updated
-    echo $renderer->display_options($options, $cm->id, $choicegroup->display, $choicegroup->publish, $choicegroup->limitanswers, $choicegroup->showresults, $current, $choicegroupopen, true, $choicegroup->multipleenrollmentspossible);
+    echo $renderer->display_options($options, $cm->id, $choicegroup->display, $choicegroup->publish, $choicegroup->limitanswers, $choicegroup->showresults, $current, $choicegroupopen, true, $choicegroup->multipleenrollmentspossible, $choicegroup->onlyactive);
 }
 $choicegroupformshown = true;
 

--- a/view.php
+++ b/view.php
@@ -199,7 +199,8 @@ if ($groupmode) {
     groups_print_activity_menu($cm, $CFG->wwwroot . '/mod/choicegroup/view.php?id='.$id);
 }
 
-$allresponses = choicegroup_get_response_data($choicegroup, $cm);   // Big function, approx 6 SQL calls per user
+// Big function, approx 6 SQL calls per user.
+$allresponses = choicegroup_get_response_data($choicegroup, $cm, $groupmode, $choicegroup->onlyactive);
 
 
 if (has_capability('mod/choicegroup:readresponses', $context)) {


### PR DESCRIPTION
This commit adds an option to filter users with expired or suspended enrolments out of the response data (in the same way as the corresponding option in mod_choice). This has been suggested by teaching staff in my institution as a quick way to tell which of the students in the 'Not answered yet' column they actually need to chase up.