### PR TITLE
Performance improvements for large courses

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -79,7 +79,8 @@ class mod_choicegroup_external extends external_api {
         require_capability('mod/choicegroup:choose', $context);
 
         $groupmode = groups_get_activity_groupmode($cm);
-        $allresponses = choicegroup_get_response_data($choicegroup, $cm, $groupmode, $choicegroup->onlyactive);
+        $current_group = $groupmode > 0 ? groups_get_activity_group($cm) : 0;
+        $options_count = choicegroup_get_options_count($choicegroup, $context, $current_group, $choicegroup->onlyactive);
         $answers = choicegroup_get_user_answer($choicegroup, $userid, true);
 
         foreach ($choicegroup->option as $optionid => $text) {
@@ -91,8 +92,8 @@ class mod_choicegroup_external extends external_api {
                 $option['maxanswers'] = $choicegroup->maxanswers[$optionid];
                 $option['displaylayout'] = $choicegroup->display;
 
-                if (isset($allresponses[$text])) {
-                    $option['countanswers'] = count($allresponses[$text]);
+                if (isset($options_count[$text])) {
+                    $option['countanswers'] = $options_count[$text];
                 } else {
                     $option['countanswers'] = 0;
                 }

--- a/renderer.php
+++ b/renderer.php
@@ -260,6 +260,8 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
         ksort($choicegroups->options);
 
         $columns = array();
+        $response_count = choicegroup_get_options_count($choicegroups, \context_module::instance($PAGE->cm->id), 0, $choicegroups->onlyactive);
+
         foreach ($choicegroups->options as $optionid => $options) {
             $coldata = '';
             if ($choicegroups->showunanswered && $optionid == 0) {
@@ -268,8 +270,8 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
                 $coldata .= html_writer::tag('div', format_string(choicegroup_get_option_text($choicegroups, $choicegroups->options[$optionid]->groupid)), array('class'=>'option'));
             }
             $numberofuser = 0;
-            if (!empty($options->user) && count($options->user) > 0) {
-                $numberofuser = count($options->user);
+            if ($response_count[$choicegroups->options[$optionid]->groupid] > 0) {
+                $numberofuser = $response_count[$choicegroups->options[$optionid]->groupid];
             }
 
             $coldata .= html_writer::tag('div', ' ('.$numberofuser. ')', array('class'=>'numberofuser', 'title' => get_string('numberofuser', 'choicegroup')));

--- a/view.php
+++ b/view.php
@@ -199,12 +199,8 @@ if ($groupmode) {
     groups_print_activity_menu($cm, $CFG->wwwroot . '/mod/choicegroup/view.php?id='.$id);
 }
 
-// Big function, approx 6 SQL calls per user.
-$allresponses = choicegroup_get_response_data($choicegroup, $cm, $groupmode, $choicegroup->onlyactive);
-
-
 if (has_capability('mod/choicegroup:readresponses', $context)) {
-    choicegroup_show_reportlink($choicegroup, $allresponses, $cm);
+    choicegroup_show_reportlink($choicegroup, $cm, $groupmode);
 }
 
 echo '<div class="clearer"></div>';
@@ -246,7 +242,7 @@ if ($choicegroup->timeclose !=0) {
     }
 }
 
-$options = choicegroup_prepare_options($choicegroup, $USER, $cm, $allresponses);
+$options = choicegroup_prepare_options($choicegroup, $USER, $cm, $groupmode);
 $renderer = $PAGE->get_renderer('mod_choicegroup');
 if ( (!$current or $choicegroup->allowupdate) and $choicegroupopen and is_enrolled($context, null, 'mod/choicegroup:choose')) {
 // They haven't made their choicegroup yet or updates allowed and choicegroup is open


### PR DESCRIPTION
Hi @ndunand,

We use this plugin on a few very large courses (> 150k enrolments) and have about ~50k responses per group.

As a result, most module result pages take a long time to load, if ever. I've adjusted the module for our use case, to work around loading all user / group records into the memory before performing some operations on them in favour of SQL counts and moodle recordsets. 

Feel free to let me know what you think. This is the current version we are using and have reduced the load time after 10k enrolments.

One thing to note is that with the introduction of pagination for the `report.php` view, the `showunanswered` option no longer works as expected, as I opted not to introduce an anti-join, or load all user enrolments into memory. For us, this is not a feature we use, thought if you have any suggestions I would be more than happy to work with you to re-introduce this.

Improvements introduced:
- Simple pagination for the `report` view. If a download action has been sent, we do not enforce a limit and proceed as usual.
- Refactoring logic around counting in favour of SQL counts
- Replace large `get_records_sql` calls with record-set iterators, where required.