### PR TITLE
Omit double headings (and intro) on Moodle ≥ 4.0.0 fixes #171.

### DIFF
--- a/view.php
+++ b/view.php
@@ -170,8 +170,9 @@ $event->add_record_snapshot('choicegroup', $choicegroup);
 $event->trigger();
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading(format_string($choicegroup->name));
-
+if ($CFG->branch < 400) {
+    echo $OUTPUT->heading(format_string($choicegroup->name));
+}
 if ($notify and confirm_sesskey()) {
     if ($notify === 'choicegroupsaved') {
         echo $OUTPUT->notification(get_string('choicegroupsaved', 'choicegroup'), 'notifysuccess');
@@ -210,7 +211,9 @@ if (has_capability('mod/choicegroup:readresponses', $context)) {
 echo '<div class="clearer"></div>';
 
 if ($choicegroup->intro) {
-    echo $OUTPUT->box(format_module_intro('choicegroup', $choicegroup, $cm->id), 'generalbox', 'intro');
+    if ($CFG->branch < 400) {
+        echo $OUTPUT->box(format_module_intro('choicegroup', $choicegroup, $cm->id), 'generalbox', 'intro');
+    }
 }
 
 //if user has already made a selection, and they are not allowed to update it, show their selected answer.


### PR DESCRIPTION
Please could you cross check this patch?