### PR TITLE
Fix course menu in single activity course format

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1036,21 +1036,21 @@ function choicegroup_supports($feature) {
  * @param navigation_node $choicegroupnode The node to add module settings to
  */
 function choicegroup_extend_settings_navigation(settings_navigation $settings, navigation_node $choicegroupnode) {
-    global $PAGE;
+    $cm = $settings->get_page()->cm;
 
-    if (has_capability('mod/choicegroup:readresponses', $PAGE->cm->context)) {
+    if (has_capability('mod/choicegroup:readresponses', $cm->context)) {
 
-        $groupmode = groups_get_activity_groupmode($PAGE->cm);
+        $groupmode = groups_get_activity_groupmode($cm);
         if ($groupmode) {
-            groups_get_activity_group($PAGE->cm, true);
+            groups_get_activity_group($cm, true);
         }
-        if (!$choicegroup = choicegroup_get_choicegroup($PAGE->cm->instance)) {
+        if (!$choicegroup = choicegroup_get_choicegroup($cm->instance)) {
             print_error('invalidcoursemodule');
             return false;
         }
 
         // Big function, approx 6 SQL calls per user.
-        $allresponses = choicegroup_get_response_data($choicegroup, $PAGE->cm, $groupmode, $choicegroup->onlyactive);
+        $allresponses = choicegroup_get_response_data($choicegroup, $cm, $groupmode, $choicegroup->onlyactive);
 
         $responsecount = 0;
         $respondents = array();
@@ -1070,7 +1070,7 @@ function choicegroup_extend_settings_navigation(settings_navigation $settings, n
         if ($choicegroup->multipleenrollmentspossible == 1) {
             $viewallresponsestext .= ' ' . get_string("byparticipants", "choicegroup", count($respondents));
         }
-        $choicegroupnode->add($viewallresponsestext, new moodle_url('/mod/choicegroup/report.php', array('id'=>$PAGE->cm->id)));
+        $choicegroupnode->add($viewallresponsestext, new moodle_url('/mod/choicegroup/report.php', array('id'=>$cm->id)));
     }
 }
 


### PR DESCRIPTION
This fixes an error when using choicegroup in a course with single activity format.

At the moment, selecting any item from the "Course" menu on the course view with single activity format will produce this error:

`Error: has_capability(): Argument #2 ($context) must be of type context, null given, called in [dirroot]/mod/choicegroup/lib.php on line 1041`

It now uses `settings_navigation` to get the course module instead of the global `$PAGE` variable.