### PR TITLE
Resolving issue with Course Completion in Moodle 4.3 (#200)

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ $id = required_param('id', PARAM_INT);   // course
 $PAGE->set_url('/mod/choicegroup/index.php', array('id' => $id));
 
 if (!$course = $DB->get_record('course', array('id' => $id))) {
-    print_error('invalidcourseid');
+    throw new moodle_exception('invalidcourseid');
 }
 
 require_course_login($course);

--- a/lib.php
+++ b/lib.php
@@ -198,12 +198,12 @@ function choicegroup_add_instance($choicegroup) {
 
     //insert answers
     $choicegroup->id = $DB->insert_record("choicegroup", $choicegroup);
-    
+
     // deserialize the selected groups
-    
+
     $groupIDs = explode(';', $choicegroup->serializedselectedgroups);
     $groupIDs = array_diff( $groupIDs, array( '' ) );
-    
+
     foreach ($groupIDs as $groupID) {
         $groupID = trim($groupID);
         if (isset($groupID) && $groupID != '') {
@@ -216,7 +216,7 @@ function choicegroup_add_instance($choicegroup) {
             }
             $option->timemodified = time();
             $DB->insert_record("choicegroup_options", $option);
-        }	
+        }
     }
 
     if (class_exists('\core_completion\api')) {
@@ -252,10 +252,10 @@ function choicegroup_update_instance($choicegroup) {
     if (empty($choicegroup->multipleenrollmentspossible)) {
         $choicegroup->multipleenrollmentspossible = 0;
     }
-    
-    
+
+
     // deserialize the selected groups
-    
+
     $groupIDs = explode(';', $choicegroup->serializedselectedgroups);
     $groupIDs = array_diff( $groupIDs, array( '' ) );
 
@@ -285,9 +285,9 @@ function choicegroup_update_instance($choicegroup) {
     				continue 2; // continue the big loop
     			}
     		}
-    		$DB->insert_record("choicegroup_options", $option);	
+    		$DB->insert_record("choicegroup_options", $option);
     	}
-    	 
+
     }
     // remove all remaining pre-existing groups which did not appear in the form (and are thus assumed to have been deleted)
     foreach ($preExistingGroups as $preExistingGroup) {
@@ -413,13 +413,13 @@ function choicegroup_user_submit_response($formanswer, $choicegroup, $userid, $c
 
     $countanswers=0;
     groups_add_member($selected_option->groupid, $userid);
-    $groupmember_added = true;    
+    $groupmember_added = true;
     if ($choicegroup->limitanswers) {
         $groupmember = $DB->get_record('groups_members', array('groupid' => $selected_option->groupid, 'userid'=>$userid));
         $select_count = 'groupid='.$selected_option->groupid.' and id<='.$groupmember->id;
         $countanswers = $DB->count_records_select('groups_members', $select_count);
         $maxans = $choicegroup->maxanswers[$formanswer];
-        if ($countanswers > $maxans) {    
+        if ($countanswers > $maxans) {
            groups_remove_member($selected_option->groupid, $userid);
            $groupmember_added = false;
       }
@@ -454,7 +454,7 @@ function choicegroup_user_submit_response($formanswer, $choicegroup, $userid, $c
         }
     } else {
         if (!$current || !($current->id==$selected_option->groupid)) { //check to see if current choicegroup already selected - if not display error
-            print_error('choicegroupfull', 'choicegroup', $CFG->wwwroot.'/mod/choicegroup/view.php?id='.$cm->id);
+            throw new moodle_exception('choicegroupfull', 'choicegroup', $CFG->wwwroot.'/mod/choicegroup/view.php?id='.$cm->id);
         }
     }
 }
@@ -960,13 +960,13 @@ function choicegroup_get_response_data($choicegroup, $cm, $groupmode, $onlyactiv
    return $allresponses;
 }
 
-/* Return an array with the options selected of users of the $choicegroup 
- * 
+/* Return an array with the options selected of users of the $choicegroup
+ *
  * @param object $choicegroup choicegroup record
  * @param context_module $ctx Context instance
  * @param int $currentgroup Current group
  * @param bool $onlyactive Whether to get responses for active users only
- * @return array of selected options by all users 
+ * @return array of selected options by all users
 */
 function choicegroup_get_responses($choicegroup, $ctx, $currentgroup, $onlyactive) {
 
@@ -1044,7 +1044,7 @@ function choicegroup_extend_settings_navigation(settings_navigation $settings, n
             groups_get_activity_group($cm, true);
         }
         if (!$choicegroup = choicegroup_get_choicegroup($cm->instance)) {
-            print_error('invalidcoursemodule');
+            throw new moodle_exception('invalidcoursemodule');
             return false;
         }
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -335,10 +335,19 @@ class mod_choicegroup_mod_form extends moodleform_mod
 
     function add_completion_rules()
     {
+        global $CFG;
+
         $mform =& $this->_form;
 
-        $mform->addElement('checkbox', 'completionsubmit', '', get_string('completionsubmit', 'choicegroup'));
-        return array('completionsubmit');
+        // Changes for Moodle 4.3 - MDL-78516.
+        if ($CFG->branch < 403) {
+            $suffix = '';
+        } else {
+            $suffix = $this->get_suffix();
+        }
+
+        $mform->addElement('checkbox', 'completionsubmit' . $suffix, '', get_string('completionsubmit', 'choicegroup'));
+        return ['completionsubmit' . $suffix];
     }
 
     function completion_rule_enabled($data)

--- a/mod_form.php
+++ b/mod_form.php
@@ -75,7 +75,6 @@ class mod_choicegroup_mod_form extends moodleform_mod
             $a->linkcourse = $CFG->wwwroot . '//course/view.php?id=' . $COURSE->id;
             $message = get_string('pleasesetonegroupor', 'choicegroup', $a);
             \core\notification::add($message, \core\notification::WARNING);
-            throw new moodle_exception('nogroupincourse', 'choicegroup', new moodle_url('/course/view.php?id=' . $COURSE->id), $a);
         }
 
         $db_groupings = $DB->get_records('groupings', array('courseid' => $COURSE->id));

--- a/mod_form.php
+++ b/mod_form.php
@@ -75,7 +75,7 @@ class mod_choicegroup_mod_form extends moodleform_mod
             $a->linkcourse = $CFG->wwwroot . '//course/view.php?id=' . $COURSE->id;
             $message = get_string('pleasesetonegroupor', 'choicegroup', $a);
             \core\notification::add($message, \core\notification::WARNING);
-            print_error('nogroupincourse', 'choicegroup', new moodle_url('/course/view.php?id=' . $COURSE->id), $a);
+            throw new moodle_exception('nogroupincourse', 'choicegroup', new moodle_url('/course/view.php?id=' . $COURSE->id), $a);
         }
 
         $db_groupings = $DB->get_records('groupings', array('courseid' => $COURSE->id));

--- a/report.php
+++ b/report.php
@@ -46,11 +46,11 @@ if ($action !== '') {
 $PAGE->set_url($url);
 
 if (! $cm = get_coursemodule_from_id('choicegroup', $id)) {
-    print_error("invalidcoursemodule");
+    throw new moodle_exception("invalidcoursemodule");
 }
 
 if (! $course = $DB->get_record("course", array("id" => $cm->course))) {
-    print_error("coursemisconf");
+    throw new moodle_exception("coursemisconf");
 }
 
 require_login($course->id, false, $cm);
@@ -60,7 +60,7 @@ $context = context_module::instance($cm->id);
 require_capability('mod/choicegroup:readresponses', $context);
 
 if (!$choicegroup = choicegroup_get_choicegroup($cm->instance)) {
-    print_error('invalidcoursemodule');
+    throw new moodle_exception('invalidcoursemodule');
 }
 
 $strchoicegroup = get_string("modulename", "choicegroup");

--- a/view.php
+++ b/view.php
@@ -41,17 +41,17 @@ if ($action !== '') {
 $PAGE->set_url($url);
 
 if (! $cm = get_coursemodule_from_id('choicegroup', $id)) {
-    print_error('invalidcoursemodule');
+    throw new moodle_exception('invalidcoursemodule');
 }
 
 if (! $course = $DB->get_record("course", array("id" => $cm->course))) {
-    print_error('coursemisconf');
+    throw new moodle_exception('coursemisconf');
 }
 
 require_login($course, false, $cm);
 $PAGE->requires->js_call_amd('mod_choicegroup/choicegroupdatadisplay', 'init');
 if (!$choicegroup = choicegroup_get_choicegroup($cm->instance)) {
-    print_error('invalidcoursemodule');
+    throw new moodle_exception('invalidcoursemodule');
 }
 $choicegroup_groups = choicegroup_get_groups($choicegroup);
 $choicegroup_users = array();
@@ -60,7 +60,7 @@ $strchoicegroup = get_string('modulename', 'choicegroup');
 $strchoicegroups = get_string('modulenameplural', 'choicegroup');
 
 if (!$context = context_module::instance($cm->id)) {
-    print_error('badcontext');
+    throw new moodle_exception('badcontext');
 }
 
 $eventparams = array(


### PR DESCRIPTION
I have mended the code as follows:

- replaced deprecated function print_error()
- added suffix to completion rules for Moodle 4.3+
- removed moodle_exception when $db_groups < 1 which would trigger the issue in #200.

The last issue was caused by replacing print_error() - now deprecated - with throw new moodle_exception.
