### PR TITLE
Adding conditional CAST on SORT BY when ordering by group name

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -844,12 +844,14 @@ function choicegroup_get_choicegroup($choicegroupid) {
             $grpfilter = "AND grp_o.groupid = :groupid";
         }
 
+        $castorderby = ($sortcolumn == 'name') ? "CAST(REGEXP_SUBSTR($sortcolumn, '[0-9]+') AS UNSIGNED)," : "";
+
         $sql = "SELECT grp_m.id grpmemberid, grp_m.userid, grp_o.id, grp_o.groupid, grp_o.maxanswers
                  FROM {groups} grp
                  INNER JOIN {choicegroup_options} grp_o on grp.id = grp_o.groupid
                  LEFT JOIN {groups_members} grp_m on grp_m.groupid = grp_o.groupid
                  WHERE grp_o.choicegroupid = :choicegroupid $grpfilter
-                 ORDER BY $sortcolumn ASC";
+                 ORDER BY $castorderby $sortcolumn ASC";
 
         $rs = $DB->get_recordset_sql($sql, $params);
 


### PR DESCRIPTION
When ordering groups by name the sorting is done alphabetically and would place "group 12" before "group 2"
This patch does a CAST to UNSIGNED on the numbers in a group name to fix that