### PR TITLE
Force size of help icon

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -156,7 +156,7 @@ class mod_choicegroup_mod_form extends moodleform_mod {
             '</label><span class="helptooltip"><a href="' . $CFG->wwwroot .
             '/help.php?component=choicegroup&amp;identifier=choicegroupoptions&amp;lang=' . current_language() .
             '" title="' . get_string('choicegroupoptions_help', 'choicegroup') .
-            '" aria-haspopup="true" target="_blank"><img src="' . $CFG->wwwroot . '/theme/image.php?theme='
+            '" aria-haspopup="true" target="_blank"><img height="24px" width="24px" src="' . $CFG->wwwroot . '/theme/image.php?theme='
             . $PAGE->theme->name . '&component=core&image=help" alt="' .
             get_string('choicegroupoptions_help', 'choicegroup') .
             '" class="iconhelp"></a></span></div><div class="felement fselect">


### PR DESCRIPTION
On Moodle 4.5 help icon takes full available space.

![image](https://github.com/user-attachments/assets/0c7d6a58-5f06-4dad-a3d4-434701850281)

After the fix icon behaves normally.

![image](https://github.com/user-attachments/assets/499b9299-b835-4520-8211-396aca8fc60b)

