### PR TITLE
Fix #229 Adding conditional CAST on SORT BY when ordering by group name

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -848,12 +848,14 @@ function choicegroup_get_choicegroup($choicegroupid) {
             $grpfilter = "AND grp_o.groupid = :groupid";
         }
 
+        $castorderby = ($sortcolumn == 'name') ? $DB->sql_cast_char2int("REGEXP_SUBSTR($sortcolumn, '[0-9]+')") . "," : "";
+
         $sql = "SELECT grp_m.id grpmemberid, grp_m.userid, grp_o.id, grp_o.groupid, grp_o.maxanswers
                  FROM {groups} grp
                  INNER JOIN {choicegroup_options} grp_o on grp.id = grp_o.groupid
                  LEFT JOIN {groups_members} grp_m on grp_m.groupid = grp_o.groupid
                  WHERE grp_o.choicegroupid = :choicegroupid $grpfilter
-                 ORDER BY $sortcolumn ASC";
+                 ORDER BY $castorderby $sortcolumn ASC";
 
         $rs = $DB->get_recordset_sql($sql, $params);
 


### PR DESCRIPTION
Use moodle's sql_cast_char2int() function to assure compatibility with all supported RDBMS