### PR TITLE
Align "Choice" and "Group" "Show descriptions" horizontally.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -240,6 +240,7 @@
 .path-mod-choicegroup a.choicegroup-memberdisplay,
 .path-mod-choicegroup a.choicegroup-descriptiondisplay {
     display: inline-block;
+    vertical-align: initial;
 }
 
 .path-mod-choicegroup div.choicegroups-membersnames.hidden,


### PR DESCRIPTION
This small tweak aligns those texts.

<img width="1053" alt="align Choice Group" src="https://github.com/user-attachments/assets/dcca01d8-18c4-478d-9b71-66b97ee8f578">
