### PR TITLE
Display unique groups in settings even if group is in several groupings

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -177,6 +177,8 @@ class mod_choicegroup_mod_form extends moodleform_mod {
                     $grouping->name . '</option>');
                 foreach ($grouping->linkedGroupsIDs as $linkedgroupid) {
                     if (isset($groups[$linkedgroupid])) {
+                        // Only add unique groups as groups can be in multiple groupings.
+                        if ($groups[$linkedgroupid]->mentioned == true) { continue; }
                         $mform->addElement('html', '<option value="' . $linkedgroupid .
                             '" class="group nested">&nbsp;&nbsp;&nbsp;&nbsp;' . $groups[$linkedgroupid]->name . '</option>');
                         $groups[$linkedgroupid]->mentioned = true;


### PR DESCRIPTION
When group is in a grouping, available options for selector control are created with `class="group nested"` attributes.
However when a group is in multiple groupings, and additionally it was selected in activity settings - it is displayed multiple times.

<img width="641" alt="group-in-multiple-groupings" src="https://github.com/user-attachments/assets/8cfa36ee-ad6b-4d91-92d8-f3498423445d" />
<img width="95" alt="selected-groups-duplicates" src="https://github.com/user-attachments/assets/32ff96d6-2558-4a27-a1f0-924f3702b8fc" />

The proposed patch checks if group was already mentioned, and if yes then such groups are skipped in settings form.
