### PR TITLE
Fix: Invert firstname and lastname columns in text export

### DIFF
--- a/report.php
+++ b/report.php
@@ -230,7 +230,7 @@ if ($download == "txt" && has_capability('mod/choicegroup:downloadresponses', $c
 
     // Print names of all the fields.
 
-    echo get_string("firstname")."\t".get_string("lastname") . "\t". get_string("idnumber") . "\t";
+    echo get_string("lastname")."\t".get_string("firstname") . "\t". get_string("idnumber") . "\t";
     echo get_string("email") . "\t";
     echo get_string("group"). "\t";
     echo get_string("choice", "choicegroup"). "\n";


### PR DESCRIPTION
This commit fixes an issue where the "firstname" and "lastname" columns were inverted in the exported text file. In the current state, the "firstname" column contains last names and vice versa. The order of `get_string` calls has been corrected to ensure the columns reflect the appropriate data.