### PR TITLE
Remove table borders in Moodle ≥ 5.0, resolves #252.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+        run: moodle-plugin-ci phpcs --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}

--- a/lib.php
+++ b/lib.php
@@ -582,7 +582,7 @@ function prepare_choicegroup_show_results($choicegroup, $course, $cm, $allrespon
                 echo '<input type="hidden" name="mode" value="overview" />';
             }
 
-            echo "<table cellpadding=\"5\" cellspacing=\"10\" class=\"results names\">";
+            echo "<table cellpadding=\"5\" cellspacing=\"10\" class=\"results names table-reboot\">";
             echo "<tr>";
 
             $columncount = []; // Number of votes in each column.

--- a/mod_form.php
+++ b/mod_form.php
@@ -157,7 +157,7 @@ class mod_choicegroup_mod_form extends moodleform_mod {
                 <div id="fitem_id_option_0" name="fitem_id_option_0" class="fitem fitem_fselect ">
                 <div class="felement fselect">
                 <div class="tablecontainer">
-                <table>
+                <table class="table-reboot">
                     <tr class="row">
                         <th class="col-lg-6">' . get_string('available_groups', 'choicegroup') . '</th>
                         <th class="col-lg-6">' . get_string('selected_groups', 'choicegroup') . '</th>
@@ -192,15 +192,15 @@ class mod_choicegroup_mod_form extends moodleform_mod {
             }
         }
         $mform->addElement('html', '</select><br><button name="expandButton" type="button" disabled id="expandButton" ' .
-            'class="btn btn-secondary">' . get_string('expand_all_groupings', 'choicegroup') .
+            'class="btn btn-secondary mb-1">' . get_string('expand_all_groupings', 'choicegroup') .
             '</button><button name="collapseButton" type="button" disabled id="collapseButton" class="btn btn-secondary">' .
             get_string('collapse_all_groupings', 'choicegroup') .
             '</button><br>' . get_string('double_click_grouping_legend', 'choicegroup') . '<br>' .
             get_string('double_click_group_legend', 'choicegroup'));
 
         $mform->addElement('html', '
-                </td><td class="col-2"><button id="addGroupButton" name="add" type="button" disabled class="btn btn-secondary">' .
-            get_string('add', 'choicegroup') .
+                </td><td class="col-2"><button id="addGroupButton" name="add" type="button" disabled ' .
+            'class="btn btn-secondary mb-1">' . get_string('add', 'choicegroup') .
             '</button><div><button name="remove" type="button" disabled id="removeGroupButton" class="btn btn-secondary">' .
             get_string('del', 'choicegroup') . '</button></div></td>');
         $mform->addElement('html', '<td style="vertical-align: top" class="col-5">

--- a/renderer.php
+++ b/renderer.php
@@ -61,7 +61,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
 
         $html = html_writer::start_tag('form', $attributes);
         $html .= html_writer::start_tag('div', ['class' => 'tablecontainer']);
-        $html .= html_writer::start_tag('table', ['class' => 'choicegroups' ]);
+        $html .= html_writer::start_tag('table', ['class' => 'choicegroups table-reboot' ]);
 
         $html .= html_writer::start_tag('tr');
         $html .= html_writer::tag('th', get_string('choice', 'choicegroup'), ['class' => 'width10']);
@@ -277,7 +277,7 @@ class mod_choicegroup_renderer extends plugin_renderer_base {
         $table = new html_table();
         $table->cellpadding = 0;
         $table->cellspacing = 0;
-        $table->attributes['class'] = 'results names ';
+        $table->attributes['class'] = 'results names table-reboot';
         $table->tablealign = 'center';
         $table->data = [];
 


### PR DESCRIPTION
Note this uses Moodle 5.0.3.
The necessary .table-reboot table class comes with that version.

Also, I allowed myself to separate the buttons visually.

<img width="808" height="572" alt="image" src="https://github.com/user-attachments/assets/68ef8bf1-5b10-472c-9054-577a7259c8df" />
